### PR TITLE
feat: migrate to Spring Boot 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
     java
-    id("org.springframework.boot") version "3.5.8"
+    id("org.springframework.boot") version "4.0.0"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -19,14 +19,14 @@ repositories {
 
 dependencies {
     // Spring Boot
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
 
     // OAuth2 Authorization Server
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+    implementation("org.springframework.boot:spring-boot-starter-security-oauth2-authorization-server")
+    implementation("org.springframework.boot:spring-boot-starter-security-oauth2-resource-server")
 
     // Database
     runtimeOnly("com.mysql:mysql-connector-j:8.4.0")
@@ -42,6 +42,7 @@ dependencies {
 
     // Monitoring
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-health")
     implementation("io.micrometer:micrometer-registry-prometheus")
 
     // Utilities
@@ -50,6 +51,8 @@ dependencies {
 
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-resttestclient")
     testImplementation("org.springframework.security:spring-security-test")
 
     // Testcontainers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - update
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.0
     container_name: eightbitbazar-elasticsearch
     environment:
       - discovery.type=single-node

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/br/com/eightbitbazar/EightBitBazarApplication.java
+++ b/src/main/java/br/com/eightbitbazar/EightBitBazarApplication.java
@@ -2,8 +2,10 @@ package br.com.eightbitbazar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class EightBitBazarApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/br/com/eightbitbazar/adapter/in/messaging/BidEventListener.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/messaging/BidEventListener.java
@@ -13,7 +13,7 @@ import br.com.eightbitbazar.domain.listing.ListingId;
 import br.com.eightbitbazar.domain.manufacturer.Manufacturer;
 import br.com.eightbitbazar.domain.platform.Platform;
 import br.com.eightbitbazar.domain.user.User;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -32,7 +32,7 @@ public class BidEventListener {
     private final UserRepository userRepository;
     private final PlatformRepository platformRepository;
     private final ManufacturerRepository manufacturerRepository;
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     public BidEventListener(
             ListingSearchRepository listingSearchRepository,
@@ -40,13 +40,13 @@ public class BidEventListener {
             UserRepository userRepository,
             PlatformRepository platformRepository,
             ManufacturerRepository manufacturerRepository,
-            ObjectMapper objectMapper) {
+            JsonMapper jsonMapper) {
         this.listingSearchRepository = listingSearchRepository;
         this.listingRepository = listingRepository;
         this.userRepository = userRepository;
         this.platformRepository = platformRepository;
         this.manufacturerRepository = manufacturerRepository;
-        this.objectMapper = objectMapper;
+        this.jsonMapper = jsonMapper;
     }
 
     @Transactional(readOnly = true)
@@ -59,7 +59,7 @@ public class BidEventListener {
 
         try {
             if ("bid.placed".equals(eventType)) {
-                handleBidPlaced(objectMapper.readValue(body, BidPlacedEvent.class));
+                handleBidPlaced(jsonMapper.readValue(body, BidPlacedEvent.class));
             } else {
                 log.warn("Unknown bid event type: {}", eventType);
             }

--- a/src/main/java/br/com/eightbitbazar/adapter/in/messaging/ListingEventListener.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/messaging/ListingEventListener.java
@@ -15,7 +15,7 @@ import br.com.eightbitbazar.domain.listing.ListingId;
 import br.com.eightbitbazar.domain.manufacturer.Manufacturer;
 import br.com.eightbitbazar.domain.platform.Platform;
 import br.com.eightbitbazar.domain.user.User;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -34,7 +34,7 @@ public class ListingEventListener {
     private final UserRepository userRepository;
     private final PlatformRepository platformRepository;
     private final ManufacturerRepository manufacturerRepository;
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     public ListingEventListener(
             ListingSearchRepository listingSearchRepository,
@@ -42,13 +42,13 @@ public class ListingEventListener {
             UserRepository userRepository,
             PlatformRepository platformRepository,
             ManufacturerRepository manufacturerRepository,
-            ObjectMapper objectMapper) {
+            JsonMapper jsonMapper) {
         this.listingSearchRepository = listingSearchRepository;
         this.listingRepository = listingRepository;
         this.userRepository = userRepository;
         this.platformRepository = platformRepository;
         this.manufacturerRepository = manufacturerRepository;
-        this.objectMapper = objectMapper;
+        this.jsonMapper = jsonMapper;
     }
 
     @Transactional(readOnly = true)
@@ -61,9 +61,9 @@ public class ListingEventListener {
 
         try {
             switch (eventType) {
-                case "listing.created" -> handleListingCreated(objectMapper.readValue(body, ListingCreatedEvent.class));
-                case "listing.deleted" -> handleListingDeleted(objectMapper.readValue(body, ListingDeletedEvent.class));
-                case "listing.sold" -> handleListingSold(objectMapper.readValue(body, ListingSoldEvent.class));
+                case "listing.created" -> handleListingCreated(jsonMapper.readValue(body, ListingCreatedEvent.class));
+                case "listing.deleted" -> handleListingDeleted(jsonMapper.readValue(body, ListingDeletedEvent.class));
+                case "listing.sold" -> handleListingSold(jsonMapper.readValue(body, ListingSoldEvent.class));
                 default -> log.warn("Unknown event type: {}", eventType);
             }
         } catch (Exception e) {

--- a/src/main/java/br/com/eightbitbazar/adapter/out/messaging/RabbitMQEventPublisher.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/out/messaging/RabbitMQEventPublisher.java
@@ -3,7 +3,7 @@ package br.com.eightbitbazar.adapter.out.messaging;
 import br.com.eightbitbazar.application.port.out.EventPublisher;
 import br.com.eightbitbazar.config.RabbitMQConfig;
 import br.com.eightbitbazar.domain.event.DomainEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
@@ -15,17 +15,17 @@ import org.springframework.stereotype.Component;
 public class RabbitMQEventPublisher implements EventPublisher {
 
     private final RabbitTemplate rabbitTemplate;
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
-    public RabbitMQEventPublisher(RabbitTemplate rabbitTemplate, ObjectMapper objectMapper) {
+    public RabbitMQEventPublisher(RabbitTemplate rabbitTemplate, JsonMapper jsonMapper) {
         this.rabbitTemplate = rabbitTemplate;
-        this.objectMapper = objectMapper;
+        this.jsonMapper = jsonMapper;
     }
 
     @Override
     public void publish(DomainEvent event) {
         try {
-            String json = objectMapper.writeValueAsString(event);
+            String json = jsonMapper.writeValueAsString(event);
 
             MessageProperties properties = new MessageProperties();
             properties.setContentType("application/json");

--- a/src/main/java/br/com/eightbitbazar/config/RabbitMQConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/RabbitMQConfig.java
@@ -1,12 +1,12 @@
 package br.com.eightbitbazar.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.json.JsonMapper;
 
 @Configuration
 public class RabbitMQConfig {
@@ -85,12 +85,12 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Jackson2JsonMessageConverter messageConverter(ObjectMapper objectMapper) {
-        return new Jackson2JsonMessageConverter(objectMapper);
+    public JacksonJsonMessageConverter messageConverter(JsonMapper jsonMapper) {
+        return new JacksonJsonMessageConverter(jsonMapper);
     }
 
     @Bean
-    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, Jackson2JsonMessageConverter messageConverter) {
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, JacksonJsonMessageConverter messageConverter) {
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMessageConverter(messageConverter);
         return template;

--- a/src/main/java/br/com/eightbitbazar/config/SecurityConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/SecurityConfig.java
@@ -19,14 +19,13 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.oidc.OidcScopes;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
-import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
@@ -51,12 +50,11 @@ public class SecurityConfig {
     @Bean
     @Order(1)
     public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
-        OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
-
-        http.getConfigurer(OAuth2AuthorizationServerConfigurer.class)
-            .oidc(Customizer.withDefaults());
-
         http
+            .securityMatcher("/oauth2/**", "/.well-known/**")
+            .oauth2AuthorizationServer(authorizationServer -> authorizationServer
+                .oidc(Customizer.withDefaults())
+            )
             .exceptionHandling(exceptions -> exceptions
                 .defaultAuthenticationEntryPointFor(
                     new LoginUrlAuthenticationEntryPoint("/login"),
@@ -162,7 +160,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtDecoder jwtDecoder(JWKSource<SecurityContext> jwkSource) {
-        return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
+        return NimbusJwtDecoder.withJwkSource(jwkSource).build();
     }
 
     @Bean

--- a/src/main/java/br/com/eightbitbazar/config/health/MinioHealthIndicator.java
+++ b/src/main/java/br/com/eightbitbazar/config/health/MinioHealthIndicator.java
@@ -1,8 +1,8 @@
 package br.com.eightbitbazar.config.health;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;

--- a/src/test/java/br/com/eightbitbazar/IntegrationTestBase.java
+++ b/src/test/java/br/com/eightbitbazar/IntegrationTestBase.java
@@ -1,6 +1,6 @@
 package br.com.eightbitbazar;
 
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -40,10 +40,9 @@ public abstract class IntegrationTestBase {
         rabbitmq = new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management"))
             .withReuse(true);
 
-        elasticsearch = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.11.0"))
+        elasticsearch = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.0.0"))
             .withEnv("xpack.security.enabled", "false")
-            .withEnv("discovery.type", "single-node")
-            .withReuse(true);
+            .withEnv("discovery.type", "single-node");
 
         mysql.start();
         minio.start();

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/AuthControllerIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/AuthControllerIntegrationTest.java
@@ -2,10 +2,10 @@ package br.com.eightbitbazar.adapter.in.web;
 
 import br.com.eightbitbazar.IntegrationTestBase;
 import br.com.eightbitbazar.adapter.in.web.dto.RegisterUserRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,7 +19,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
     private MockMvc mockMvc;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private JsonMapper jsonMapper;
 
     @Test
     void shouldRegisterUser() throws Exception {
@@ -41,7 +41,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
 
         mockMvc.perform(post("/api/v1/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content(jsonMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.email").value("test@example.com"))
             .andExpect(jsonPath("$.nickname").value("testuser"))
@@ -64,7 +64,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
         // First registration
         mockMvc.perform(post("/api/v1/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content(jsonMapper.writeValueAsString(request)))
             .andExpect(status().isCreated());
 
         // Second registration with same email
@@ -81,7 +81,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
 
         mockMvc.perform(post("/api/v1/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(duplicateRequest)))
+                .content(jsonMapper.writeValueAsString(duplicateRequest)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("Email already registered"));
     }
@@ -101,7 +101,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
 
         mockMvc.perform(post("/api/v1/auth/register")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content(jsonMapper.writeValueAsString(request)))
             .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
  - Update Spring Boot from 3.5.8 to 4.0.0
  - Update Gradle from 8.5 to 8.14
  - Rename starters: web → webmvc, oauth2 starters → security-oauth2
  - Add spring-boot-health and spring-boot-starter-webmvc-test modules

  Jackson 3.x migration:
  - Replace com.fasterxml.jackson with tools.jackson
  - Use JsonMapper instead of ObjectMapper
  - Update JacksonJsonMessageConverter for RabbitMQ

  Spring Security 7 changes:
  - Update OAuth2 configuration to use http.oauth2AuthorizationServer()
  - Replace OAuth2AuthorizationServerConfiguration with NimbusJwtDecoder

  Package relocations:
  - Health: org.springframework.boot.actuate.health → org.springframework.boot.health.contributor
  - MockMvc: org.springframework.boot.test.autoconfigure.web.servlet → org.springframework.boot.webmvc.test.autoconfigure

  Infrastructure updates:
  - Elasticsearch 8.11.0 → 9.0.0 (required by elasticsearch-java 9.2.1)
  - Enable stable Page serialization via @EnableSpringDataWebSupport