### PR TITLE
feat: add user trade history and auction closing flows

### DIFF
--- a/src/main/java/br/com/eightbitbazar/EightBitBazarApplication.java
+++ b/src/main/java/br/com/eightbitbazar/EightBitBazarApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class EightBitBazarApplication {
 

--- a/src/main/java/br/com/eightbitbazar/adapter/in/messaging/PurchaseEventListener.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/messaging/PurchaseEventListener.java
@@ -1,0 +1,40 @@
+package br.com.eightbitbazar.adapter.in.messaging;
+
+import br.com.eightbitbazar.config.RabbitMQConfig;
+import br.com.eightbitbazar.domain.event.PurchaseCompletedEvent;
+import io.micrometer.core.instrument.Counter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.json.JsonMapper;
+
+@Slf4j
+@Component
+public class PurchaseEventListener {
+
+    private final JsonMapper jsonMapper;
+    private final Counter purchaseEventsConsumedCounter;
+
+    public PurchaseEventListener(JsonMapper jsonMapper, Counter purchaseEventsConsumedCounter) {
+        this.jsonMapper = jsonMapper;
+        this.purchaseEventsConsumedCounter = purchaseEventsConsumedCounter;
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.PURCHASE_EVENTS_QUEUE)
+    public void handlePurchaseEvent(Message message) {
+        String eventType = message.getMessageProperties().getHeader("eventType");
+
+        if (!"purchase.completed".equals(eventType)) {
+            return;
+        }
+
+        try {
+            PurchaseCompletedEvent event = jsonMapper.readValue(message.getBody(), PurchaseCompletedEvent.class);
+            purchaseEventsConsumedCounter.increment();
+            log.info("Processed purchase.completed event for purchaseId={}", event.purchaseId());
+        } catch (Exception e) {
+            log.error("Failed to process purchase event: {}", eventType, e);
+        }
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingScheduler.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingScheduler.java
@@ -1,0 +1,20 @@
+package br.com.eightbitbazar.adapter.in.scheduling;
+
+import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuctionClosingScheduler {
+
+    private final CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase;
+
+    public AuctionClosingScheduler(CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase) {
+        this.closeExpiredAuctionsUseCase = closeExpiredAuctionsUseCase;
+    }
+
+    @Scheduled(fixedDelayString = "${app.auctions.closing.fixed-delay:60000}")
+    public void closeExpiredAuctions() {
+        closeExpiredAuctionsUseCase.execute();
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingScheduler.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingScheduler.java
@@ -1,10 +1,12 @@
 package br.com.eightbitbazar.adapter.in.scheduling;
 
 import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(prefix = "app.auctions.closing", name = "enabled", havingValue = "true")
 public class AuctionClosingScheduler {
 
     private final CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase;

--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
@@ -125,6 +125,7 @@ public class UserController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
+        validatePagination(page, size);
         UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
         Page<UserTradeHistoryResponse> response = getMyPurchasesUseCase.execute(userId, page, size)
             .map(this::toTradeHistoryResponse);
@@ -137,10 +138,20 @@ public class UserController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size
     ) {
+        validatePagination(page, size);
         UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
         Page<UserTradeHistoryResponse> response = getMySalesUseCase.execute(userId, page, size)
             .map(this::toTradeHistoryResponse);
         return ResponseEntity.ok(response);
+    }
+
+    private void validatePagination(int page, int size) {
+        if (page < 0) {
+            throw new IllegalArgumentException("Page must be greater than or equal to 0");
+        }
+        if (size < 1 || size > 100) {
+            throw new IllegalArgumentException("Size must be between 1 and 100");
+        }
     }
 
     private UserTradeHistoryResponse toTradeHistoryResponse(UserTradeHistoryItemOutput output) {

--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
@@ -1,14 +1,19 @@
 package br.com.eightbitbazar.adapter.in.web;
 
+import br.com.eightbitbazar.adapter.in.web.dto.UserTradeHistoryResponse;
 import br.com.eightbitbazar.adapter.in.web.dto.UpdateUserRequest;
 import br.com.eightbitbazar.adapter.in.web.dto.UserResponse;
 import br.com.eightbitbazar.application.port.in.DeleteUserUseCase;
+import br.com.eightbitbazar.application.port.in.GetMyPurchasesUseCase;
+import br.com.eightbitbazar.application.port.in.GetMySalesUseCase;
 import br.com.eightbitbazar.application.port.in.GetUserProfileUseCase;
 import br.com.eightbitbazar.application.port.in.UpdateUserProfileUseCase;
 import br.com.eightbitbazar.application.usecase.user.UpdateUserProfileInput;
 import br.com.eightbitbazar.application.usecase.user.UpdateUserProfileOutput;
+import br.com.eightbitbazar.application.usecase.user.UserTradeHistoryItemOutput;
 import br.com.eightbitbazar.application.usecase.user.UserProfileOutput;
 import br.com.eightbitbazar.domain.user.UserId;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -21,15 +26,21 @@ public class UserController {
     private final GetUserProfileUseCase getUserProfileUseCase;
     private final UpdateUserProfileUseCase updateUserProfileUseCase;
     private final DeleteUserUseCase deleteUserUseCase;
+    private final GetMyPurchasesUseCase getMyPurchasesUseCase;
+    private final GetMySalesUseCase getMySalesUseCase;
 
     public UserController(
         GetUserProfileUseCase getUserProfileUseCase,
         UpdateUserProfileUseCase updateUserProfileUseCase,
-        DeleteUserUseCase deleteUserUseCase
+        DeleteUserUseCase deleteUserUseCase,
+        GetMyPurchasesUseCase getMyPurchasesUseCase,
+        GetMySalesUseCase getMySalesUseCase
     ) {
         this.getUserProfileUseCase = getUserProfileUseCase;
         this.updateUserProfileUseCase = updateUserProfileUseCase;
         this.deleteUserUseCase = deleteUserUseCase;
+        this.getMyPurchasesUseCase = getMyPurchasesUseCase;
+        this.getMySalesUseCase = getMySalesUseCase;
     }
 
     @GetMapping("/me")
@@ -106,5 +117,44 @@ public class UserController {
         UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
         deleteUserUseCase.execute(userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me/purchases")
+    public ResponseEntity<Page<UserTradeHistoryResponse>> getMyPurchases(
+        @AuthenticationPrincipal Jwt jwt,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
+        Page<UserTradeHistoryResponse> response = getMyPurchasesUseCase.execute(userId, page, size)
+            .map(this::toTradeHistoryResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me/sales")
+    public ResponseEntity<Page<UserTradeHistoryResponse>> getMySales(
+        @AuthenticationPrincipal Jwt jwt,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
+        Page<UserTradeHistoryResponse> response = getMySalesUseCase.execute(userId, page, size)
+            .map(this::toTradeHistoryResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    private UserTradeHistoryResponse toTradeHistoryResponse(UserTradeHistoryItemOutput output) {
+        return new UserTradeHistoryResponse(
+            output.purchaseId(),
+            output.listingId(),
+            output.listingTitle(),
+            output.listingType(),
+            output.listingStatus(),
+            output.amount(),
+            output.finalAmount(),
+            output.paymentMethod(),
+            output.purchaseStatus(),
+            output.createdAt()
+        );
     }
 }

--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/dto/UserTradeHistoryResponse.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/dto/UserTradeHistoryResponse.java
@@ -1,0 +1,18 @@
+package br.com.eightbitbazar.adapter.in.web.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record UserTradeHistoryResponse(
+    Long purchaseId,
+    Long listingId,
+    String listingTitle,
+    String listingType,
+    String listingStatus,
+    BigDecimal amount,
+    BigDecimal finalAmount,
+    String paymentMethod,
+    String purchaseStatus,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/br/com/eightbitbazar/adapter/out/persistence/ListingRepositoryAdapter.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/out/persistence/ListingRepositoryAdapter.java
@@ -11,7 +11,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public class ListingRepositoryAdapter implements ListingRepository {
@@ -35,6 +38,24 @@ public class ListingRepositoryAdapter implements ListingRepository {
     public Optional<Listing> findById(ListingId id) {
         return jpaListingRepository.findById(id.value())
             .map(listingMapper::toDomain);
+    }
+
+    @Override
+    public List<Listing> findByIds(Set<ListingId> ids) {
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        return jpaListingRepository.findAllById(ids.stream().map(ListingId::value).toList()).stream()
+            .map(listingMapper::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<Listing> findExpiredActiveAuctions(LocalDateTime now) {
+        return jpaListingRepository.findExpiredActiveAuctions(List.of("AUCTION"), "ACTIVE", now).stream()
+            .map(listingMapper::toDomain)
+            .toList();
     }
 
     @Override

--- a/src/main/java/br/com/eightbitbazar/adapter/out/persistence/ListingRepositoryAdapter.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/out/persistence/ListingRepositoryAdapter.java
@@ -52,10 +52,16 @@ public class ListingRepositoryAdapter implements ListingRepository {
     }
 
     @Override
-    public List<Listing> findExpiredActiveAuctions(LocalDateTime now) {
-        return jpaListingRepository.findExpiredActiveAuctions(List.of("AUCTION"), "ACTIVE", now).stream()
-            .map(listingMapper::toDomain)
+    public List<ListingId> findExpiredActiveAuctionIds(LocalDateTime now) {
+        return jpaListingRepository.findExpiredActiveAuctionIds("AUCTION", "ACTIVE", now).stream()
+            .map(ListingId::new)
             .toList();
+    }
+
+    @Override
+    public Optional<Listing> findExpiredActiveAuctionForUpdate(ListingId id, LocalDateTime now) {
+        return jpaListingRepository.findExpiredActiveAuctionForUpdate(id.value(), "AUCTION", "ACTIVE", now)
+            .map(listingMapper::toDomain);
     }
 
     @Override

--- a/src/main/java/br/com/eightbitbazar/adapter/out/persistence/repository/JpaListingRepository.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/out/persistence/repository/JpaListingRepository.java
@@ -7,9 +7,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface JpaListingRepository extends JpaRepository<ListingEntity, Long> {
 
     Page<ListingEntity> findBySellerId(Long sellerId, Pageable pageable);
+
+    @Query("""
+        SELECT l FROM ListingEntity l
+        WHERE l.deletedAt IS NULL
+          AND l.type IN :types
+          AND l.status = :status
+          AND l.auctionEndDate IS NOT NULL
+          AND l.auctionEndDate < :now
+        """)
+    List<ListingEntity> findExpiredActiveAuctions(
+        @Param("types") List<String> types,
+        @Param("status") String status,
+        @Param("now") java.time.LocalDateTime now
+    );
 
     @Query("SELECT l FROM ListingEntity l WHERE l.deletedAt IS NULL " +
            "AND (:search IS NULL OR LOWER(l.name) LIKE LOWER(CONCAT('%', :search, '%'))) " +

--- a/src/main/java/br/com/eightbitbazar/adapter/out/persistence/repository/JpaListingRepository.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/out/persistence/repository/JpaListingRepository.java
@@ -1,28 +1,49 @@
 package br.com.eightbitbazar.adapter.out.persistence.repository;
 
 import br.com.eightbitbazar.adapter.out.persistence.entity.ListingEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface JpaListingRepository extends JpaRepository<ListingEntity, Long> {
 
     Page<ListingEntity> findBySellerId(Long sellerId, Pageable pageable);
 
     @Query("""
-        SELECT l FROM ListingEntity l
+        SELECT l.id FROM ListingEntity l
         WHERE l.deletedAt IS NULL
-          AND l.type IN :types
+          AND l.type = :type
+          AND l.status = :status
+          AND l.auctionEndDate IS NOT NULL
+          AND l.auctionEndDate < :now
+        ORDER BY l.auctionEndDate ASC, l.id ASC
+        """)
+    List<Long> findExpiredActiveAuctionIds(
+        @Param("type") String type,
+        @Param("status") String status,
+        @Param("now") java.time.LocalDateTime now
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT l FROM ListingEntity l
+        WHERE l.id = :id
+          AND l.deletedAt IS NULL
+          AND l.type = :type
           AND l.status = :status
           AND l.auctionEndDate IS NOT NULL
           AND l.auctionEndDate < :now
         """)
-    List<ListingEntity> findExpiredActiveAuctions(
-        @Param("types") List<String> types,
+    Optional<ListingEntity> findExpiredActiveAuctionForUpdate(
+        @Param("id") Long id,
+        @Param("type") String type,
         @Param("status") String status,
         @Param("now") java.time.LocalDateTime now
     );

--- a/src/main/java/br/com/eightbitbazar/application/port/in/CloseExpiredAuctionsUseCase.java
+++ b/src/main/java/br/com/eightbitbazar/application/port/in/CloseExpiredAuctionsUseCase.java
@@ -1,0 +1,6 @@
+package br.com.eightbitbazar.application.port.in;
+
+public interface CloseExpiredAuctionsUseCase {
+
+    int execute();
+}

--- a/src/main/java/br/com/eightbitbazar/application/port/in/GetMyPurchasesUseCase.java
+++ b/src/main/java/br/com/eightbitbazar/application/port/in/GetMyPurchasesUseCase.java
@@ -1,0 +1,10 @@
+package br.com.eightbitbazar.application.port.in;
+
+import br.com.eightbitbazar.application.usecase.user.UserTradeHistoryItemOutput;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.springframework.data.domain.Page;
+
+public interface GetMyPurchasesUseCase {
+
+    Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size);
+}

--- a/src/main/java/br/com/eightbitbazar/application/port/in/GetMySalesUseCase.java
+++ b/src/main/java/br/com/eightbitbazar/application/port/in/GetMySalesUseCase.java
@@ -1,0 +1,10 @@
+package br.com.eightbitbazar.application.port.in;
+
+import br.com.eightbitbazar.application.usecase.user.UserTradeHistoryItemOutput;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.springframework.data.domain.Page;
+
+public interface GetMySalesUseCase {
+
+    Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size);
+}

--- a/src/main/java/br/com/eightbitbazar/application/port/out/ListingRepository.java
+++ b/src/main/java/br/com/eightbitbazar/application/port/out/ListingRepository.java
@@ -6,13 +6,20 @@ import br.com.eightbitbazar.domain.user.UserId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ListingRepository {
 
     Listing save(Listing listing);
 
     Optional<Listing> findById(ListingId id);
+
+    List<Listing> findByIds(Set<ListingId> ids);
+
+    List<Listing> findExpiredActiveAuctions(LocalDateTime now);
 
     Page<Listing> findAll(ListingSearchCriteria criteria, Pageable pageable);
 

--- a/src/main/java/br/com/eightbitbazar/application/port/out/ListingRepository.java
+++ b/src/main/java/br/com/eightbitbazar/application/port/out/ListingRepository.java
@@ -19,7 +19,9 @@ public interface ListingRepository {
 
     List<Listing> findByIds(Set<ListingId> ids);
 
-    List<Listing> findExpiredActiveAuctions(LocalDateTime now);
+    List<ListingId> findExpiredActiveAuctionIds(LocalDateTime now);
+
+    Optional<Listing> findExpiredActiveAuctionForUpdate(ListingId id, LocalDateTime now);
 
     Page<Listing> findAll(ListingSearchCriteria criteria, Pageable pageable);
 

--- a/src/main/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctions.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctions.java
@@ -1,0 +1,108 @@
+package br.com.eightbitbazar.application.usecase.listing;
+
+import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
+import br.com.eightbitbazar.application.port.out.BidRepository;
+import br.com.eightbitbazar.application.port.out.EventPublisher;
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.bid.Bid;
+import br.com.eightbitbazar.domain.event.AuctionEndedEvent;
+import br.com.eightbitbazar.domain.event.ListingSoldEvent;
+import br.com.eightbitbazar.domain.event.PurchaseCompletedEvent;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingStatus;
+import br.com.eightbitbazar.domain.purchase.PaymentMethod;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.purchase.PurchaseStatus;
+import br.com.eightbitbazar.domain.purchase.PurchaseType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Transactional
+public class CloseExpiredAuctions implements CloseExpiredAuctionsUseCase {
+
+    private final ListingRepository listingRepository;
+    private final BidRepository bidRepository;
+    private final PurchaseRepository purchaseRepository;
+    private final EventPublisher eventPublisher;
+
+    public CloseExpiredAuctions(
+        ListingRepository listingRepository,
+        BidRepository bidRepository,
+        PurchaseRepository purchaseRepository,
+        EventPublisher eventPublisher
+    ) {
+        this.listingRepository = listingRepository;
+        this.bidRepository = bidRepository;
+        this.purchaseRepository = purchaseRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public int execute() {
+        List<Listing> expiredAuctions = listingRepository.findExpiredActiveAuctions(LocalDateTime.now());
+
+        expiredAuctions.forEach(this::closeAuction);
+        return expiredAuctions.size();
+    }
+
+    private void closeAuction(Listing listing) {
+        Optional<Bid> highestBid = bidRepository.findHighestBidByListingId(listing.id());
+
+        if (highestBid.isPresent()) {
+            closeWithWinner(listing, highestBid.get());
+            return;
+        }
+
+        Listing expiredListing = listing.withStatus(ListingStatus.EXPIRED);
+        listingRepository.save(expiredListing);
+        eventPublisher.publish(new AuctionEndedEvent(
+            listing.id().value(),
+            listing.sellerId().value(),
+            null,
+            null
+        ));
+    }
+
+    private void closeWithWinner(Listing listing, Bid highestBid) {
+        Purchase savedPurchase = purchaseRepository.save(new Purchase(
+            null,
+            listing.id(),
+            highestBid.userId(),
+            listing.sellerId(),
+            highestBid.amount(),
+            PurchaseType.AUCTION_WIN,
+            PaymentMethod.OTHER,
+            java.math.BigDecimal.ZERO,
+            highestBid.amount(),
+            PurchaseStatus.PENDING,
+            LocalDateTime.now()
+        ));
+
+        Listing soldListing = listing.withStatus(ListingStatus.SOLD).withQuantity(0);
+        listingRepository.save(soldListing);
+
+        eventPublisher.publish(new AuctionEndedEvent(
+            listing.id().value(),
+            listing.sellerId().value(),
+            highestBid.userId().value(),
+            highestBid.amount()
+        ));
+        eventPublisher.publish(new PurchaseCompletedEvent(
+            savedPurchase.id(),
+            savedPurchase.listingId().value(),
+            savedPurchase.buyerId().value(),
+            savedPurchase.sellerId().value(),
+            savedPurchase.finalAmount(),
+            savedPurchase.paymentMethod().name()
+        ));
+        eventPublisher.publish(new ListingSoldEvent(
+            listing.id().value(),
+            highestBid.userId().value(),
+            listing.sellerId().value()
+        ));
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctions.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctions.java
@@ -10,6 +10,7 @@ import br.com.eightbitbazar.domain.event.AuctionEndedEvent;
 import br.com.eightbitbazar.domain.event.ListingSoldEvent;
 import br.com.eightbitbazar.domain.event.PurchaseCompletedEvent;
 import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
 import br.com.eightbitbazar.domain.listing.ListingStatus;
 import br.com.eightbitbazar.domain.purchase.PaymentMethod;
 import br.com.eightbitbazar.domain.purchase.Purchase;
@@ -43,10 +44,19 @@ public class CloseExpiredAuctions implements CloseExpiredAuctionsUseCase {
 
     @Override
     public int execute() {
-        List<Listing> expiredAuctions = listingRepository.findExpiredActiveAuctions(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        List<ListingId> candidateIds = listingRepository.findExpiredActiveAuctionIds(now);
 
-        expiredAuctions.forEach(this::closeAuction);
-        return expiredAuctions.size();
+        int processed = 0;
+        for (ListingId listingId : candidateIds) {
+            Optional<Listing> lockedListing = listingRepository.findExpiredActiveAuctionForUpdate(listingId, now);
+            if (lockedListing.isEmpty()) {
+                continue;
+            }
+            closeAuction(lockedListing.get());
+            processed++;
+        }
+        return processed;
     }
 
     private void closeAuction(Listing listing) {

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
@@ -1,0 +1,59 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import br.com.eightbitbazar.application.port.in.GetMyPurchasesUseCase;
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class GetMyPurchases implements GetMyPurchasesUseCase {
+
+    private final PurchaseRepository purchaseRepository;
+    private final ListingRepository listingRepository;
+
+    public GetMyPurchases(PurchaseRepository purchaseRepository, ListingRepository listingRepository) {
+        this.purchaseRepository = purchaseRepository;
+        this.listingRepository = listingRepository;
+    }
+
+    @Override
+    public Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size) {
+        Page<Purchase> purchases = purchaseRepository.findByBuyerId(userId, PageRequest.of(page, size));
+        Map<ListingId, Listing> listingsById = loadListings(purchases);
+
+        return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));
+    }
+
+    private Map<ListingId, Listing> loadListings(Page<Purchase> purchases) {
+        Set<ListingId> listingIds = purchases.getContent().stream()
+            .map(Purchase::listingId)
+            .collect(Collectors.toSet());
+
+        return listingRepository.findByIds(listingIds).stream()
+            .collect(Collectors.toMap(Listing::id, Function.identity()));
+    }
+
+    private UserTradeHistoryItemOutput toOutput(Purchase purchase, Listing listing) {
+        return new UserTradeHistoryItemOutput(
+            purchase.id(),
+            purchase.listingId().value(),
+            listing != null ? listing.name() : null,
+            listing != null ? listing.type().name() : null,
+            listing != null ? listing.status().name() : null,
+            purchase.amount(),
+            purchase.finalAmount(),
+            purchase.paymentMethod() != null ? purchase.paymentMethod().name() : null,
+            purchase.status().name(),
+            purchase.createdAt()
+        );
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
@@ -1,29 +1,21 @@
 package br.com.eightbitbazar.application.usecase.user;
 
 import br.com.eightbitbazar.application.port.in.GetMyPurchasesUseCase;
-import br.com.eightbitbazar.application.port.out.ListingRepository;
 import br.com.eightbitbazar.application.port.out.PurchaseRepository;
-import br.com.eightbitbazar.domain.listing.Listing;
-import br.com.eightbitbazar.domain.listing.ListingId;
 import br.com.eightbitbazar.domain.purchase.Purchase;
 import br.com.eightbitbazar.domain.user.UserId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 public class GetMyPurchases implements GetMyPurchasesUseCase {
 
     private final PurchaseRepository purchaseRepository;
-    private final ListingRepository listingRepository;
+    private final UserTradeHistoryMapper tradeHistoryMapper;
 
-    public GetMyPurchases(PurchaseRepository purchaseRepository, ListingRepository listingRepository) {
+    public GetMyPurchases(PurchaseRepository purchaseRepository, UserTradeHistoryMapper tradeHistoryMapper) {
         this.purchaseRepository = purchaseRepository;
-        this.listingRepository = listingRepository;
+        this.tradeHistoryMapper = tradeHistoryMapper;
     }
 
     @Override
@@ -32,32 +24,7 @@ public class GetMyPurchases implements GetMyPurchasesUseCase {
             userId,
             PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         );
-        Map<ListingId, Listing> listingsById = loadListings(purchases);
-
-        return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));
-    }
-
-    private Map<ListingId, Listing> loadListings(Page<Purchase> purchases) {
-        Set<ListingId> listingIds = purchases.getContent().stream()
-            .map(Purchase::listingId)
-            .collect(Collectors.toSet());
-
-        return listingRepository.findByIds(listingIds).stream()
-            .collect(Collectors.toMap(Listing::id, Function.identity()));
-    }
-
-    private UserTradeHistoryItemOutput toOutput(Purchase purchase, Listing listing) {
-        return new UserTradeHistoryItemOutput(
-            purchase.id(),
-            purchase.listingId().value(),
-            listing != null ? listing.name() : null,
-            listing != null ? listing.type().name() : null,
-            listing != null ? listing.status().name() : null,
-            purchase.amount(),
-            purchase.finalAmount(),
-            purchase.paymentMethod() != null ? purchase.paymentMethod().name() : null,
-            purchase.status().name(),
-            purchase.createdAt()
-        );
+        return tradeHistoryMapper.map(purchases);
     }
 }
+

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchases.java
@@ -9,6 +9,7 @@ import br.com.eightbitbazar.domain.purchase.Purchase;
 import br.com.eightbitbazar.domain.user.UserId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +28,10 @@ public class GetMyPurchases implements GetMyPurchasesUseCase {
 
     @Override
     public Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size) {
-        Page<Purchase> purchases = purchaseRepository.findByBuyerId(userId, PageRequest.of(page, size));
+        Page<Purchase> purchases = purchaseRepository.findByBuyerId(
+            userId,
+            PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
         Map<ListingId, Listing> listingsById = loadListings(purchases);
 
         return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
@@ -1,0 +1,59 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import br.com.eightbitbazar.application.port.in.GetMySalesUseCase;
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class GetMySales implements GetMySalesUseCase {
+
+    private final PurchaseRepository purchaseRepository;
+    private final ListingRepository listingRepository;
+
+    public GetMySales(PurchaseRepository purchaseRepository, ListingRepository listingRepository) {
+        this.purchaseRepository = purchaseRepository;
+        this.listingRepository = listingRepository;
+    }
+
+    @Override
+    public Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size) {
+        Page<Purchase> purchases = purchaseRepository.findBySellerId(userId, PageRequest.of(page, size));
+        Map<ListingId, Listing> listingsById = loadListings(purchases);
+
+        return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));
+    }
+
+    private Map<ListingId, Listing> loadListings(Page<Purchase> purchases) {
+        Set<ListingId> listingIds = purchases.getContent().stream()
+            .map(Purchase::listingId)
+            .collect(Collectors.toSet());
+
+        return listingRepository.findByIds(listingIds).stream()
+            .collect(Collectors.toMap(Listing::id, Function.identity()));
+    }
+
+    private UserTradeHistoryItemOutput toOutput(Purchase purchase, Listing listing) {
+        return new UserTradeHistoryItemOutput(
+            purchase.id(),
+            purchase.listingId().value(),
+            listing != null ? listing.name() : null,
+            listing != null ? listing.type().name() : null,
+            listing != null ? listing.status().name() : null,
+            purchase.amount(),
+            purchase.finalAmount(),
+            purchase.paymentMethod() != null ? purchase.paymentMethod().name() : null,
+            purchase.status().name(),
+            purchase.createdAt()
+        );
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
@@ -1,29 +1,21 @@
 package br.com.eightbitbazar.application.usecase.user;
 
 import br.com.eightbitbazar.application.port.in.GetMySalesUseCase;
-import br.com.eightbitbazar.application.port.out.ListingRepository;
 import br.com.eightbitbazar.application.port.out.PurchaseRepository;
-import br.com.eightbitbazar.domain.listing.Listing;
-import br.com.eightbitbazar.domain.listing.ListingId;
 import br.com.eightbitbazar.domain.purchase.Purchase;
 import br.com.eightbitbazar.domain.user.UserId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 public class GetMySales implements GetMySalesUseCase {
 
     private final PurchaseRepository purchaseRepository;
-    private final ListingRepository listingRepository;
+    private final UserTradeHistoryMapper tradeHistoryMapper;
 
-    public GetMySales(PurchaseRepository purchaseRepository, ListingRepository listingRepository) {
+    public GetMySales(PurchaseRepository purchaseRepository, UserTradeHistoryMapper tradeHistoryMapper) {
         this.purchaseRepository = purchaseRepository;
-        this.listingRepository = listingRepository;
+        this.tradeHistoryMapper = tradeHistoryMapper;
     }
 
     @Override
@@ -32,32 +24,7 @@ public class GetMySales implements GetMySalesUseCase {
             userId,
             PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         );
-        Map<ListingId, Listing> listingsById = loadListings(purchases);
-
-        return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));
-    }
-
-    private Map<ListingId, Listing> loadListings(Page<Purchase> purchases) {
-        Set<ListingId> listingIds = purchases.getContent().stream()
-            .map(Purchase::listingId)
-            .collect(Collectors.toSet());
-
-        return listingRepository.findByIds(listingIds).stream()
-            .collect(Collectors.toMap(Listing::id, Function.identity()));
-    }
-
-    private UserTradeHistoryItemOutput toOutput(Purchase purchase, Listing listing) {
-        return new UserTradeHistoryItemOutput(
-            purchase.id(),
-            purchase.listingId().value(),
-            listing != null ? listing.name() : null,
-            listing != null ? listing.type().name() : null,
-            listing != null ? listing.status().name() : null,
-            purchase.amount(),
-            purchase.finalAmount(),
-            purchase.paymentMethod() != null ? purchase.paymentMethod().name() : null,
-            purchase.status().name(),
-            purchase.createdAt()
-        );
+        return tradeHistoryMapper.map(purchases);
     }
 }
+

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/GetMySales.java
@@ -9,6 +9,7 @@ import br.com.eightbitbazar.domain.purchase.Purchase;
 import br.com.eightbitbazar.domain.user.UserId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +28,10 @@ public class GetMySales implements GetMySalesUseCase {
 
     @Override
     public Page<UserTradeHistoryItemOutput> execute(UserId userId, int page, int size) {
-        Page<Purchase> purchases = purchaseRepository.findBySellerId(userId, PageRequest.of(page, size));
+        Page<Purchase> purchases = purchaseRepository.findBySellerId(
+            userId,
+            PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
         Map<ListingId, Listing> listingsById = loadListings(purchases);
 
         return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/UserTradeHistoryItemOutput.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/UserTradeHistoryItemOutput.java
@@ -1,0 +1,18 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record UserTradeHistoryItemOutput(
+    Long purchaseId,
+    Long listingId,
+    String listingTitle,
+    String listingType,
+    String listingStatus,
+    BigDecimal amount,
+    BigDecimal finalAmount,
+    String paymentMethod,
+    String purchaseStatus,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/UserTradeHistoryMapper.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/UserTradeHistoryMapper.java
@@ -1,0 +1,50 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import org.springframework.data.domain.Page;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class UserTradeHistoryMapper {
+
+    private final ListingRepository listingRepository;
+
+    public UserTradeHistoryMapper(ListingRepository listingRepository) {
+        this.listingRepository = listingRepository;
+    }
+
+    public Page<UserTradeHistoryItemOutput> map(Page<Purchase> purchases) {
+        Map<ListingId, Listing> listingsById = loadListings(purchases);
+        return purchases.map(purchase -> toOutput(purchase, listingsById.get(purchase.listingId())));
+    }
+
+    private Map<ListingId, Listing> loadListings(Page<Purchase> purchases) {
+        Set<ListingId> listingIds = purchases.getContent().stream()
+            .map(Purchase::listingId)
+            .collect(Collectors.toSet());
+
+        return listingRepository.findByIds(listingIds).stream()
+            .collect(Collectors.toMap(Listing::id, Function.identity()));
+    }
+
+    private UserTradeHistoryItemOutput toOutput(Purchase purchase, Listing listing) {
+        return new UserTradeHistoryItemOutput(
+            purchase.id(),
+            purchase.listingId().value(),
+            listing != null ? listing.name() : null,
+            listing != null ? listing.type().name() : null,
+            listing != null ? listing.status().name() : null,
+            purchase.amount(),
+            purchase.finalAmount(),
+            purchase.paymentMethod() != null ? purchase.paymentMethod().name() : null,
+            purchase.status().name(),
+            purchase.createdAt()
+        );
+    }
+}

--- a/src/main/java/br/com/eightbitbazar/config/MetricsConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/MetricsConfig.java
@@ -38,6 +38,13 @@ public class MetricsConfig {
     }
 
     @Bean
+    public Counter purchaseEventsConsumedCounter(MeterRegistry registry) {
+        return Counter.builder("eightbitbazar.purchase.events.consumed")
+                .description("Total number of purchase events consumed from RabbitMQ")
+                .register(registry);
+    }
+
+    @Bean
     public Counter usersRegisteredCounter(MeterRegistry registry) {
         return Counter.builder("eightbitbazar.users.registered")
                 .description("Total number of users registered")

--- a/src/main/java/br/com/eightbitbazar/config/UseCaseConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/UseCaseConfig.java
@@ -36,6 +36,22 @@ public class UseCaseConfig {
         return new DeleteUser(userRepository);
     }
 
+    @Bean
+    public GetMyPurchasesUseCase getMyPurchasesUseCase(
+        PurchaseRepository purchaseRepository,
+        ListingRepository listingRepository
+    ) {
+        return new GetMyPurchases(purchaseRepository, listingRepository);
+    }
+
+    @Bean
+    public GetMySalesUseCase getMySalesUseCase(
+        PurchaseRepository purchaseRepository,
+        ListingRepository listingRepository
+    ) {
+        return new GetMySales(purchaseRepository, listingRepository);
+    }
+
     // Listing Use Cases
     @Bean
     public CreateListingUseCase createListingUseCase(
@@ -118,6 +134,16 @@ public class UseCaseConfig {
         EventPublisher eventPublisher
     ) {
         return new DirectPurchase(purchaseRepository, listingRepository, eventPublisher);
+    }
+
+    @Bean
+    public CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase(
+        ListingRepository listingRepository,
+        BidRepository bidRepository,
+        PurchaseRepository purchaseRepository,
+        EventPublisher eventPublisher
+    ) {
+        return new CloseExpiredAuctions(listingRepository, bidRepository, purchaseRepository, eventPublisher);
     }
 
     // Admin Use Cases

--- a/src/main/java/br/com/eightbitbazar/config/UseCaseConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/UseCaseConfig.java
@@ -37,19 +37,24 @@ public class UseCaseConfig {
     }
 
     @Bean
+    public UserTradeHistoryMapper userTradeHistoryMapper(ListingRepository listingRepository) {
+        return new UserTradeHistoryMapper(listingRepository);
+    }
+
+    @Bean
     public GetMyPurchasesUseCase getMyPurchasesUseCase(
         PurchaseRepository purchaseRepository,
-        ListingRepository listingRepository
+        UserTradeHistoryMapper userTradeHistoryMapper
     ) {
-        return new GetMyPurchases(purchaseRepository, listingRepository);
+        return new GetMyPurchases(purchaseRepository, userTradeHistoryMapper);
     }
 
     @Bean
     public GetMySalesUseCase getMySalesUseCase(
         PurchaseRepository purchaseRepository,
-        ListingRepository listingRepository
+        UserTradeHistoryMapper userTradeHistoryMapper
     ) {
-        return new GetMySales(purchaseRepository, listingRepository);
+        return new GetMySales(purchaseRepository, userTradeHistoryMapper);
     }
 
     // Listing Use Cases

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,12 @@ minio:
 server:
   port: 8080
 
+app:
+  auctions:
+    closing:
+      enabled: false
+      fixed-delay: 60000
+
 # Actuator & Prometheus
 management:
   endpoints:

--- a/src/test/java/br/com/eightbitbazar/adapter/in/messaging/PurchaseEventListenerTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/messaging/PurchaseEventListenerTest.java
@@ -1,0 +1,52 @@
+package br.com.eightbitbazar.adapter.in.messaging;
+
+import br.com.eightbitbazar.domain.event.PurchaseCompletedEvent;
+import io.micrometer.core.instrument.Counter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.math.BigDecimal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PurchaseEventListenerTest {
+
+    private JsonMapper jsonMapper;
+    private Counter purchaseEventsConsumedCounter;
+    private PurchaseEventListener purchaseEventListener;
+
+    @BeforeEach
+    void setUp() {
+        jsonMapper = mock(JsonMapper.class);
+        purchaseEventsConsumedCounter = mock(Counter.class);
+        purchaseEventListener = new PurchaseEventListener(jsonMapper, purchaseEventsConsumedCounter);
+    }
+
+    @Test
+    void shouldConsumePurchaseCompletedEventAndIncrementCounter() throws Exception {
+        PurchaseCompletedEvent event = new PurchaseCompletedEvent(
+            10L,
+            20L,
+            30L,
+            40L,
+            new BigDecimal("99.90"),
+            "PIX"
+        );
+
+        MessageProperties properties = new MessageProperties();
+        properties.setHeader("eventType", "purchase.completed");
+        Message message = new Message("{\"purchaseId\":10}".getBytes(), properties);
+
+        when(jsonMapper.readValue(message.getBody(), PurchaseCompletedEvent.class)).thenReturn(event);
+
+        purchaseEventListener.handlePurchaseEvent(message);
+
+        verify(jsonMapper).readValue(message.getBody(), PurchaseCompletedEvent.class);
+        verify(purchaseEventsConsumedCounter).increment();
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingSchedulerTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/scheduling/AuctionClosingSchedulerTest.java
@@ -1,0 +1,20 @@
+package br.com.eightbitbazar.adapter.in.scheduling;
+
+import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AuctionClosingSchedulerTest {
+
+    @Test
+    void shouldDelegateScheduledRunToCloseExpiredAuctionsUseCase() {
+        CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase = mock(CloseExpiredAuctionsUseCase.class);
+        AuctionClosingScheduler scheduler = new AuctionClosingScheduler(closeExpiredAuctionsUseCase);
+
+        scheduler.closeExpiredAuctions();
+
+        verify(closeExpiredAuctionsUseCase).execute();
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/AuctionClosingIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/AuctionClosingIntegrationTest.java
@@ -4,12 +4,14 @@ import br.com.eightbitbazar.IntegrationTestBase;
 import br.com.eightbitbazar.adapter.in.web.dto.CreateListingRequest;
 import br.com.eightbitbazar.adapter.out.persistence.repository.JpaListingRepository;
 import br.com.eightbitbazar.adapter.out.persistence.repository.JpaPurchaseRepository;
+import br.com.eightbitbazar.adapter.out.persistence.repository.JpaUserRepository;
 import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
 import br.com.eightbitbazar.support.IntegrationTestFixtures;
 import tools.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,6 +41,9 @@ class AuctionClosingIntegrationTest extends IntegrationTestBase {
 
     @Autowired
     private JpaPurchaseRepository jpaPurchaseRepository;
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
 
     @Test
     void shouldCloseExpiredAuctionWithWinnerAndCreatePurchase() throws Exception {
@@ -107,12 +112,14 @@ class AuctionClosingIntegrationTest extends IntegrationTestBase {
 
     @Test
     void shouldExpireAuctionWithoutWinnerOnlyOnce() throws Exception {
+        String sellerEmail = "seller-auction-expire@test.com";
         String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
         Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Auction Expire Platform");
         Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Auction Expire Manufacturer");
         String sellerToken = IntegrationTestFixtures.registerAndLogin(
-            mockMvc, jsonMapper, "seller-auction-expire@test.com", "Seller@123", "sellerauctionexpire", true
+            mockMvc, jsonMapper, sellerEmail, "Seller@123", "sellerauctionexpire", true
         );
+        Long sellerId = jpaUserRepository.findByEmail(sellerEmail).orElseThrow().getId();
 
         Long listingId = IntegrationTestFixtures.createListing(
             mockMvc,
@@ -141,12 +148,89 @@ class AuctionClosingIntegrationTest extends IntegrationTestBase {
 
         assertEquals(1, firstRun);
         assertEquals(0, secondRun);
-        assertEquals(0, jpaPurchaseRepository.count());
+        long purchasesForListing = jpaPurchaseRepository.findBySellerId(sellerId, Pageable.unpaged()).stream()
+            .filter(purchase -> purchase.getListingId().equals(listingId))
+            .count();
+        assertEquals(0, purchasesForListing);
 
         mockMvc.perform(get("/api/v1/listings/" + listingId)
                 .header("Authorization", "Bearer " + sellerToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("EXPIRED"));
+    }
+
+    @Test
+    void shouldCloseExpiredAuctionWithWinnerOnlyOnce() throws Exception {
+        String suffix = String.valueOf(System.nanoTime());
+        String buyerEmail = "buyer-auction-idempotent-" + suffix + "@test.com";
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(
+            mockMvc, jsonMapper, adminToken, "Auction Idempotent Platform " + suffix
+        );
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(
+            mockMvc, jsonMapper, adminToken, "Auction Idempotent Manufacturer " + suffix
+        );
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc,
+            jsonMapper,
+            "seller-auction-idempotent-" + suffix + "@test.com",
+            "Seller@123",
+            "sellerauctionidempotent" + suffix,
+            true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc,
+            jsonMapper,
+            buyerEmail,
+            "Buyer@123",
+            "buyerauctionidempotent" + suffix,
+            false
+        );
+        Long buyerId = jpaUserRepository.findByEmail(buyerEmail).orElseThrow().getId();
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Silent Hill",
+                "Completo",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "AUCTION",
+                null,
+                new BigDecimal("90.00"),
+                new BigDecimal("180.00"),
+                LocalDateTime.now().plusHours(1),
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + listingId + "/bids")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"amount\":120.00}"))
+            .andExpect(status().isCreated());
+
+        expireListing(listingId);
+
+        int firstRun = closeExpiredAuctionsUseCase.execute();
+        int secondRun = closeExpiredAuctionsUseCase.execute();
+
+        assertEquals(1, firstRun);
+        assertEquals(0, secondRun);
+        long purchasesForListing = jpaPurchaseRepository.findByBuyerId(buyerId, Pageable.unpaged()).stream()
+            .filter(purchase -> purchase.getListingId().equals(listingId))
+            .count();
+        assertEquals(1, purchasesForListing);
+
+        mockMvc.perform(get("/api/v1/listings/" + listingId)
+                .header("Authorization", "Bearer " + buyerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("SOLD"))
+            .andExpect(jsonPath("$.quantity").value(0));
     }
 
     private void expireListing(Long listingId) {

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/AuctionClosingIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/AuctionClosingIntegrationTest.java
@@ -1,0 +1,158 @@
+package br.com.eightbitbazar.adapter.in.web;
+
+import br.com.eightbitbazar.IntegrationTestBase;
+import br.com.eightbitbazar.adapter.in.web.dto.CreateListingRequest;
+import br.com.eightbitbazar.adapter.out.persistence.repository.JpaListingRepository;
+import br.com.eightbitbazar.adapter.out.persistence.repository.JpaPurchaseRepository;
+import br.com.eightbitbazar.application.port.in.CloseExpiredAuctionsUseCase;
+import br.com.eightbitbazar.support.IntegrationTestFixtures;
+import tools.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Fechamento de leiloes expirados")
+class AuctionClosingIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
+    @Autowired
+    private CloseExpiredAuctionsUseCase closeExpiredAuctionsUseCase;
+
+    @Autowired
+    private JpaListingRepository jpaListingRepository;
+
+    @Autowired
+    private JpaPurchaseRepository jpaPurchaseRepository;
+
+    @Test
+    void shouldCloseExpiredAuctionWithWinnerAndCreatePurchase() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Auction Closing Platform");
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Auction Closing Manufacturer");
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-auction-close@test.com", "Seller@123", "sellerauctionclose", true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer-auction-close@test.com", "Buyer@123", "buyerauctionclose", false
+        );
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Resident Evil 2",
+                "Midia original",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "AUCTION",
+                null,
+                new BigDecimal("80.00"),
+                new BigDecimal("150.00"),
+                LocalDateTime.now().plusHours(2),
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + listingId + "/bids")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"amount\":100.00}"))
+            .andExpect(status().isCreated());
+
+        expireListing(listingId);
+
+        int processed = closeExpiredAuctionsUseCase.execute();
+
+        assertEquals(1, processed);
+
+        mockMvc.perform(get("/api/v1/listings/" + listingId)
+                .header("Authorization", "Bearer " + buyerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("SOLD"))
+            .andExpect(jsonPath("$.quantity").value(0));
+
+        mockMvc.perform(get("/api/v1/users/me/purchases")
+                .header("Authorization", "Bearer " + buyerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].listingId").value(listingId))
+            .andExpect(jsonPath("$.content[0].listingTitle").value("Resident Evil 2"))
+            .andExpect(jsonPath("$.content[0].amount").value(100.00))
+            .andExpect(jsonPath("$.content[0].paymentMethod").value("OTHER"));
+
+        mockMvc.perform(get("/api/v1/users/me/sales")
+                .header("Authorization", "Bearer " + sellerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].listingId").value(listingId))
+            .andExpect(jsonPath("$.content[0].listingTitle").value("Resident Evil 2"));
+    }
+
+    @Test
+    void shouldExpireAuctionWithoutWinnerOnlyOnce() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Auction Expire Platform");
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Auction Expire Manufacturer");
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-auction-expire@test.com", "Seller@123", "sellerauctionexpire", true
+        );
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Chrono Cross",
+                "Completo",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "AUCTION",
+                null,
+                new BigDecimal("50.00"),
+                new BigDecimal("120.00"),
+                LocalDateTime.now().plusHours(1),
+                null
+            )
+        );
+
+        expireListing(listingId);
+
+        int firstRun = closeExpiredAuctionsUseCase.execute();
+        int secondRun = closeExpiredAuctionsUseCase.execute();
+
+        assertEquals(1, firstRun);
+        assertEquals(0, secondRun);
+        assertEquals(0, jpaPurchaseRepository.count());
+
+        mockMvc.perform(get("/api/v1/listings/" + listingId)
+                .header("Authorization", "Bearer " + sellerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("EXPIRED"));
+    }
+
+    private void expireListing(Long listingId) {
+        jpaListingRepository.findById(listingId).ifPresent(entity -> {
+            entity.setAuctionEndDate(LocalDateTime.now().minusMinutes(5));
+            jpaListingRepository.save(entity);
+        });
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/PurchaseEventFlowIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/PurchaseEventFlowIntegrationTest.java
@@ -1,0 +1,91 @@
+package br.com.eightbitbazar.adapter.in.web;
+
+import br.com.eightbitbazar.IntegrationTestBase;
+import br.com.eightbitbazar.adapter.in.web.dto.CreateListingRequest;
+import br.com.eightbitbazar.support.IntegrationTestFixtures;
+import io.micrometer.core.instrument.MeterRegistry;
+import tools.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Fluxo de eventos de compra")
+class PurchaseEventFlowIntegrationTest extends IntegrationTestBase {
+
+    private static final String PURCHASE_EVENTS_CONSUMED_METER = "eightbitbazar.purchase.events.consumed";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Test
+    void directPurchaseShouldPublishConsumablePurchaseCompletedEvent() throws Exception {
+        double initialCount = meterRegistry.get(PURCHASE_EVENTS_CONSUMED_METER).counter().count();
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Purchase Event Platform");
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Purchase Event Manufacturer");
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-purchase-event@test.com", "Seller@123", "sellerpurchaseevent", true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer-purchase-event@test.com", "Buyer@123", "buyerpurchaseevent", false
+        );
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Metal Gear Solid",
+                "Completo",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("200.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + listingId + "/purchase")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        assertTrue(awaitCounterIncrement(initialCount, Duration.ofSeconds(10)));
+    }
+
+    private boolean awaitCounterIncrement(double initialCount, Duration timeout) throws InterruptedException {
+        Instant deadline = Instant.now().plus(timeout);
+
+        while (Instant.now().isBefore(deadline)) {
+            double currentCount = meterRegistry.get(PURCHASE_EVENTS_CONSUMED_METER).counter().count();
+            if (currentCount > initialCount) {
+                return true;
+            }
+            Thread.sleep(200);
+        }
+
+        return meterRegistry.get(PURCHASE_EVENTS_CONSUMED_METER).counter().count() > initialCount;
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
@@ -234,4 +234,78 @@ class UserTradeHistoryIntegrationTest extends IntegrationTestBase {
             .andExpect(jsonPath("$.content[0].listingId").value(secondListingId))
             .andExpect(jsonPath("$.content[1].listingId").value(firstListingId));
     }
+
+    @Test
+    void shouldListSalesNewestFirst() throws Exception {
+        String suffix = Long.toString(System.nanoTime());
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Sales Newest Platform " + suffix);
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Sales Newest Manufacturer " + suffix);
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-salesnew-" + suffix + "@test.com", "Seller@123", "sellersnew" + suffix, true
+        );
+        String buyer1Token = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer1-salesnew-" + suffix + "@test.com", "Buyer@123", "buyer1snew" + suffix, false
+        );
+        String buyer2Token = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer2-salesnew-" + suffix + "@test.com", "Buyer@123", "buyer2snew" + suffix, false
+        );
+
+        Long firstListingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "First Sold Game",
+                "Older sale",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("100.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+        Long secondListingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Second Sold Game",
+                "Newer sale",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("120.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + firstListingId + "/purchase")
+                .header("Authorization", "Bearer " + buyer1Token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/listings/" + secondListingId + "/purchase")
+                .header("Authorization", "Bearer " + buyer2Token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/users/me/sales")
+                .header("Authorization", "Bearer " + sellerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].listingId").value(secondListingId))
+            .andExpect(jsonPath("$.content[1].listingId").value(firstListingId));
+    }
 }

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
@@ -129,4 +129,109 @@ class UserTradeHistoryIntegrationTest extends IntegrationTestBase {
             .andExpect(jsonPath("$.content[0].paymentMethod").value("CREDIT_CARD"))
             .andExpect(jsonPath("$.content[0].purchaseStatus").value("PENDING"));
     }
+
+    @Test
+    void shouldRejectInvalidPurchasesPagination() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+
+        mockMvc.perform(get("/api/v1/users/me/purchases")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("page", "-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Page must be greater than or equal to 0"));
+
+        mockMvc.perform(get("/api/v1/users/me/purchases")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("size", "101"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Size must be between 1 and 100"));
+    }
+
+    @Test
+    void shouldRejectInvalidSalesPagination() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+
+        mockMvc.perform(get("/api/v1/users/me/sales")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("page", "-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Page must be greater than or equal to 0"));
+
+        mockMvc.perform(get("/api/v1/users/me/sales")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("size", "0"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Size must be between 1 and 100"));
+    }
+
+    @Test
+    void shouldListPurchasesNewestFirst() throws Exception {
+        String suffix = Long.toString(System.nanoTime());
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Newest First Platform " + suffix);
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Newest First Manufacturer " + suffix);
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-newest-" + suffix + "@test.com", "Seller@123", "sellernewest" + suffix, true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer-newest-" + suffix + "@test.com", "Buyer@123", "buyernewest" + suffix, false
+        );
+
+        Long firstListingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "First Chrono Trigger",
+                "First purchase",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("100.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+        Long secondListingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Second Chrono Trigger",
+                "Second purchase",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("120.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + firstListingId + "/purchase")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/listings/" + secondListingId + "/purchase")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/users/me/purchases")
+                .header("Authorization", "Bearer " + buyerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].listingId").value(secondListingId))
+            .andExpect(jsonPath("$.content[1].listingId").value(firstListingId));
+    }
 }

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/UserTradeHistoryIntegrationTest.java
@@ -1,0 +1,132 @@
+package br.com.eightbitbazar.adapter.in.web;
+
+import br.com.eightbitbazar.IntegrationTestBase;
+import br.com.eightbitbazar.adapter.in.web.dto.CreateListingRequest;
+import br.com.eightbitbazar.support.IntegrationTestFixtures;
+import tools.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Historico comercial do usuario")
+class UserTradeHistoryIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
+    @Test
+    void shouldListAuthenticatedUserPurchases() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Trade History Platform");
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Trade History Manufacturer");
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-history@test.com", "Seller@123", "sellerhistory", true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer-history@test.com", "Buyer@123", "buyerhistory", false
+        );
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Shadow of the Colossus",
+                "Com manual",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("100.00"),
+                null,
+                null,
+                null,
+                new BigDecimal("5.00")
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + listingId + "/purchase")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"PIX\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/users/me/purchases")
+                .header("Authorization", "Bearer " + buyerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].purchaseId").exists())
+            .andExpect(jsonPath("$.content[0].listingId").value(listingId))
+            .andExpect(jsonPath("$.content[0].listingTitle").value("Shadow of the Colossus"))
+            .andExpect(jsonPath("$.content[0].listingType").value("DIRECT_SALE"))
+            .andExpect(jsonPath("$.content[0].listingStatus").value("SOLD"))
+            .andExpect(jsonPath("$.content[0].amount").value(100.00))
+            .andExpect(jsonPath("$.content[0].finalAmount").value(95.00))
+            .andExpect(jsonPath("$.content[0].paymentMethod").value("PIX"))
+            .andExpect(jsonPath("$.content[0].purchaseStatus").value("PENDING"));
+    }
+
+    @Test
+    void shouldListAuthenticatedUserSales() throws Exception {
+        String adminToken = IntegrationTestFixtures.loginAsAdmin(mockMvc, jsonMapper);
+        Long platformId = IntegrationTestFixtures.createPlatform(mockMvc, jsonMapper, adminToken, "Sales History Platform");
+        Long manufacturerId = IntegrationTestFixtures.createManufacturer(mockMvc, jsonMapper, adminToken, "Sales History Manufacturer");
+        String sellerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "seller-sales-history@test.com", "Seller@123", "sellersaleshistory", true
+        );
+        String buyerToken = IntegrationTestFixtures.registerAndLogin(
+            mockMvc, jsonMapper, "buyer-sales-history@test.com", "Buyer@123", "buyersaleshistory", false
+        );
+
+        Long listingId = IntegrationTestFixtures.createListing(
+            mockMvc,
+            jsonMapper,
+            sellerToken,
+            new CreateListingRequest(
+                "Resident Evil 2",
+                "Midia original",
+                platformId,
+                manufacturerId,
+                "COMPLETE",
+                1,
+                "DIRECT_SALE",
+                new BigDecimal("150.00"),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/listings/" + listingId + "/purchase")
+                .header("Authorization", "Bearer " + buyerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentMethod\":\"CREDIT_CARD\"}"))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/users/me/sales")
+                .header("Authorization", "Bearer " + sellerToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].purchaseId").exists())
+            .andExpect(jsonPath("$.content[0].listingId").value(listingId))
+            .andExpect(jsonPath("$.content[0].listingTitle").value("Resident Evil 2"))
+            .andExpect(jsonPath("$.content[0].listingType").value("DIRECT_SALE"))
+            .andExpect(jsonPath("$.content[0].listingStatus").value("SOLD"))
+            .andExpect(jsonPath("$.content[0].amount").value(150.00))
+            .andExpect(jsonPath("$.content[0].finalAmount").value(150.00))
+            .andExpect(jsonPath("$.content[0].paymentMethod").value("CREDIT_CARD"))
+            .andExpect(jsonPath("$.content[0].purchaseStatus").value("PENDING"));
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctionsTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctionsTest.java
@@ -32,8 +32,10 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,7 +76,10 @@ class CloseExpiredAuctionsTest {
             LocalDateTime.of(2026, 3, 1, 9, 0)
         );
 
-        when(listingRepository.findExpiredActiveAuctions(any(LocalDateTime.class))).thenReturn(List.of(expiredAuction));
+        when(listingRepository.findExpiredActiveAuctionIds(any(LocalDateTime.class)))
+            .thenReturn(List.of(new ListingId(55L)));
+        when(listingRepository.findExpiredActiveAuctionForUpdate(eq(new ListingId(55L)), any(LocalDateTime.class)))
+            .thenReturn(Optional.of(expiredAuction));
         when(bidRepository.findHighestBidByListingId(new ListingId(55L))).thenReturn(Optional.of(winningBid));
         when(purchaseRepository.save(any(Purchase.class))).thenAnswer(invocation -> {
             Purchase purchase = invocation.getArgument(0);
@@ -126,7 +131,10 @@ class CloseExpiredAuctionsTest {
     void shouldExpireListingWithoutCreatingPurchaseWhenExpiredAuctionHasNoBids() {
         Listing expiredAuction = expiredAuctionListing(66L, 21L);
 
-        when(listingRepository.findExpiredActiveAuctions(any(LocalDateTime.class))).thenReturn(List.of(expiredAuction));
+        when(listingRepository.findExpiredActiveAuctionIds(any(LocalDateTime.class)))
+            .thenReturn(List.of(new ListingId(66L)));
+        when(listingRepository.findExpiredActiveAuctionForUpdate(eq(new ListingId(66L)), any(LocalDateTime.class)))
+            .thenReturn(Optional.of(expiredAuction));
         when(bidRepository.findHighestBidByListingId(new ListingId(66L))).thenReturn(Optional.empty());
 
         int processed = closeExpiredAuctions.execute();
@@ -144,6 +152,19 @@ class CloseExpiredAuctionsTest {
                 && auctionEndedEvent.winnerId() == null
                 && auctionEndedEvent.winningBid() == null
         ));
+    }
+
+    @Test
+    void shouldSkipCandidateWhenAuctionIsAlreadyProcessedBeforeLock() {
+        when(listingRepository.findExpiredActiveAuctionIds(any(LocalDateTime.class)))
+            .thenReturn(List.of(new ListingId(77L)));
+        when(listingRepository.findExpiredActiveAuctionForUpdate(eq(new ListingId(77L)), any(LocalDateTime.class)))
+            .thenReturn(Optional.empty());
+
+        int processed = closeExpiredAuctions.execute();
+
+        assertEquals(0, processed);
+        verifyNoInteractions(bidRepository, purchaseRepository, eventPublisher);
     }
 
     private Listing expiredAuctionListing(Long listingId, Long sellerId) {

--- a/src/test/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctionsTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/listing/CloseExpiredAuctionsTest.java
@@ -1,0 +1,172 @@
+package br.com.eightbitbazar.application.usecase.listing;
+
+import br.com.eightbitbazar.application.port.out.BidRepository;
+import br.com.eightbitbazar.application.port.out.EventPublisher;
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.bid.Bid;
+import br.com.eightbitbazar.domain.event.AuctionEndedEvent;
+import br.com.eightbitbazar.domain.event.ListingSoldEvent;
+import br.com.eightbitbazar.domain.event.PurchaseCompletedEvent;
+import br.com.eightbitbazar.domain.listing.ItemCondition;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.listing.ListingStatus;
+import br.com.eightbitbazar.domain.listing.ListingType;
+import br.com.eightbitbazar.domain.purchase.PaymentMethod;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.purchase.PurchaseStatus;
+import br.com.eightbitbazar.domain.purchase.PurchaseType;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloseExpiredAuctionsTest {
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private PurchaseRepository purchaseRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    private CloseExpiredAuctions closeExpiredAuctions;
+
+    @BeforeEach
+    void setUp() {
+        closeExpiredAuctions = new CloseExpiredAuctions(
+            listingRepository,
+            bidRepository,
+            purchaseRepository,
+            eventPublisher
+        );
+    }
+
+    @Test
+    void shouldCreateAuctionWinPurchaseAndMarkListingAsSoldWhenExpiredAuctionHasWinner() {
+        Listing expiredAuction = expiredAuctionListing(55L, 20L);
+        Bid winningBid = new Bid(
+            80L,
+            new ListingId(55L),
+            new UserId(10L),
+            new BigDecimal("150.00"),
+            LocalDateTime.of(2026, 3, 1, 9, 0)
+        );
+
+        when(listingRepository.findExpiredActiveAuctions(any(LocalDateTime.class))).thenReturn(List.of(expiredAuction));
+        when(bidRepository.findHighestBidByListingId(new ListingId(55L))).thenReturn(Optional.of(winningBid));
+        when(purchaseRepository.save(any(Purchase.class))).thenAnswer(invocation -> {
+            Purchase purchase = invocation.getArgument(0);
+            return purchase.withId(999L);
+        });
+
+        int processed = closeExpiredAuctions.execute();
+
+        assertEquals(1, processed);
+        verify(purchaseRepository).save(argThat(purchase ->
+            purchase.listingId().value().equals(55L)
+                && purchase.buyerId().value().equals(10L)
+                && purchase.sellerId().value().equals(20L)
+                && purchase.amount().compareTo(new BigDecimal("150.00")) == 0
+                && purchase.type() == PurchaseType.AUCTION_WIN
+                && purchase.paymentMethod() == PaymentMethod.OTHER
+                && purchase.status() == PurchaseStatus.PENDING
+        ));
+        verify(listingRepository).save(argThat(listing ->
+            listing.id().value().equals(55L)
+                && listing.status() == ListingStatus.SOLD
+                && listing.quantity() == 0
+        ));
+        verify(eventPublisher).publish(argThat(event ->
+            event instanceof AuctionEndedEvent auctionEndedEvent
+                && auctionEndedEvent.listingId().equals(55L)
+                && auctionEndedEvent.sellerId().equals(20L)
+                && auctionEndedEvent.winnerId().equals(10L)
+                && auctionEndedEvent.winningBid().compareTo(new BigDecimal("150.00")) == 0
+        ));
+        verify(eventPublisher).publish(argThat(event ->
+            event instanceof PurchaseCompletedEvent purchaseCompletedEvent
+                && purchaseCompletedEvent.purchaseId().equals(999L)
+                && purchaseCompletedEvent.listingId().equals(55L)
+                && purchaseCompletedEvent.buyerId().equals(10L)
+                && purchaseCompletedEvent.sellerId().equals(20L)
+                && purchaseCompletedEvent.totalAmount().compareTo(new BigDecimal("150.00")) == 0
+                && purchaseCompletedEvent.paymentMethod().equals("OTHER")
+        ));
+        verify(eventPublisher).publish(argThat(event ->
+            event instanceof ListingSoldEvent listingSoldEvent
+                && listingSoldEvent.listingId().equals(55L)
+                && listingSoldEvent.buyerId().equals(10L)
+                && listingSoldEvent.sellerId().equals(20L)
+        ));
+    }
+
+    @Test
+    void shouldExpireListingWithoutCreatingPurchaseWhenExpiredAuctionHasNoBids() {
+        Listing expiredAuction = expiredAuctionListing(66L, 21L);
+
+        when(listingRepository.findExpiredActiveAuctions(any(LocalDateTime.class))).thenReturn(List.of(expiredAuction));
+        when(bidRepository.findHighestBidByListingId(new ListingId(66L))).thenReturn(Optional.empty());
+
+        int processed = closeExpiredAuctions.execute();
+
+        assertEquals(1, processed);
+        verify(purchaseRepository, never()).save(any(Purchase.class));
+        verify(listingRepository).save(argThat(listing ->
+            listing.id().value().equals(66L)
+                && listing.status() == ListingStatus.EXPIRED
+        ));
+        verify(eventPublisher).publish(argThat(event ->
+            event instanceof AuctionEndedEvent auctionEndedEvent
+                && auctionEndedEvent.listingId().equals(66L)
+                && auctionEndedEvent.sellerId().equals(21L)
+                && auctionEndedEvent.winnerId() == null
+                && auctionEndedEvent.winningBid() == null
+        ));
+    }
+
+    private Listing expiredAuctionListing(Long listingId, Long sellerId) {
+        return new Listing(
+            new ListingId(listingId),
+            new UserId(sellerId),
+            "Auction Listing " + listingId,
+            "Expired auction",
+            1L,
+            2L,
+            ItemCondition.COMPLETE,
+            1,
+            ListingType.AUCTION,
+            null,
+            new BigDecimal("80.00"),
+            new BigDecimal("150.00"),
+            LocalDateTime.of(2026, 2, 28, 10, 0),
+            null,
+            ListingStatus.ACTIVE,
+            List.of(),
+            LocalDateTime.of(2026, 2, 27, 10, 0),
+            LocalDateTime.of(2026, 2, 28, 10, 0),
+            null
+        );
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
@@ -1,0 +1,109 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.listing.ItemCondition;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.listing.ListingStatus;
+import br.com.eightbitbazar.domain.listing.ListingType;
+import br.com.eightbitbazar.domain.purchase.PaymentMethod;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.purchase.PurchaseStatus;
+import br.com.eightbitbazar.domain.purchase.PurchaseType;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetMyPurchasesTest {
+
+    @Mock
+    private PurchaseRepository purchaseRepository;
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    private GetMyPurchases getMyPurchases;
+
+    @BeforeEach
+    void setUp() {
+        getMyPurchases = new GetMyPurchases(purchaseRepository, listingRepository);
+    }
+
+    @Test
+    void shouldReturnBuyerHistoryWithListingSummary() {
+        UserId buyerId = new UserId(10L);
+        ListingId listingId = new ListingId(55L);
+        Purchase purchase = new Purchase(
+            99L,
+            listingId,
+            buyerId,
+            new UserId(20L),
+            new BigDecimal("100.00"),
+            PurchaseType.DIRECT,
+            PaymentMethod.PIX,
+            BigDecimal.ZERO,
+            new BigDecimal("95.00"),
+            PurchaseStatus.PENDING,
+            LocalDateTime.of(2026, 3, 1, 10, 0)
+        );
+        Listing listing = new Listing(
+            listingId,
+            new UserId(20L),
+            "Shadow of the Colossus",
+            "Com manual",
+            1L,
+            2L,
+            ItemCondition.COMPLETE,
+            1,
+            ListingType.DIRECT_SALE,
+            new BigDecimal("100.00"),
+            null,
+            null,
+            null,
+            null,
+            ListingStatus.SOLD,
+            List.of(),
+            LocalDateTime.of(2026, 2, 28, 10, 0),
+            LocalDateTime.of(2026, 3, 1, 10, 0),
+            null
+        );
+
+        when(purchaseRepository.findByBuyerId(buyerId, PageRequest.of(0, 20)))
+            .thenReturn(new PageImpl<>(List.of(purchase), PageRequest.of(0, 20), 1));
+        when(listingRepository.findByIds(Set.of(listingId))).thenReturn(List.of(listing));
+
+        Page<UserTradeHistoryItemOutput> output = getMyPurchases.execute(buyerId, 0, 20);
+
+        assertEquals(1, output.getTotalElements());
+        assertEquals(99L, output.getContent().get(0).purchaseId());
+        assertEquals(55L, output.getContent().get(0).listingId());
+        assertEquals("Shadow of the Colossus", output.getContent().get(0).listingTitle());
+        assertEquals("DIRECT_SALE", output.getContent().get(0).listingType());
+        assertEquals("SOLD", output.getContent().get(0).listingStatus());
+        assertEquals(new BigDecimal("100.00"), output.getContent().get(0).amount());
+        assertEquals(new BigDecimal("95.00"), output.getContent().get(0).finalAmount());
+        assertEquals("PIX", output.getContent().get(0).paymentMethod());
+        assertEquals("PENDING", output.getContent().get(0).purchaseStatus());
+        assertEquals(LocalDateTime.of(2026, 3, 1, 10, 0), output.getContent().get(0).createdAt());
+
+        verify(purchaseRepository).findByBuyerId(buyerId, PageRequest.of(0, 20));
+        verify(listingRepository).findByIds(Set.of(listingId));
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
@@ -44,7 +44,8 @@ class GetMyPurchasesTest {
 
     @BeforeEach
     void setUp() {
-        getMyPurchases = new GetMyPurchases(purchaseRepository, listingRepository);
+        UserTradeHistoryMapper tradeHistoryMapper = new UserTradeHistoryMapper(listingRepository);
+        getMyPurchases = new GetMyPurchases(purchaseRepository, tradeHistoryMapper);
     }
 
     @Test

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMyPurchasesTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -85,8 +86,9 @@ class GetMyPurchasesTest {
             null
         );
 
-        when(purchaseRepository.findByBuyerId(buyerId, PageRequest.of(0, 20)))
-            .thenReturn(new PageImpl<>(List.of(purchase), PageRequest.of(0, 20), 1));
+        PageRequest pageRequest = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        when(purchaseRepository.findByBuyerId(buyerId, pageRequest))
+            .thenReturn(new PageImpl<>(List.of(purchase), pageRequest, 1));
         when(listingRepository.findByIds(Set.of(listingId))).thenReturn(List.of(listing));
 
         Page<UserTradeHistoryItemOutput> output = getMyPurchases.execute(buyerId, 0, 20);
@@ -103,7 +105,7 @@ class GetMyPurchasesTest {
         assertEquals("PENDING", output.getContent().get(0).purchaseStatus());
         assertEquals(LocalDateTime.of(2026, 3, 1, 10, 0), output.getContent().get(0).createdAt());
 
-        verify(purchaseRepository).findByBuyerId(buyerId, PageRequest.of(0, 20));
+        verify(purchaseRepository).findByBuyerId(buyerId, pageRequest);
         verify(listingRepository).findByIds(Set.of(listingId));
     }
 }

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
@@ -1,0 +1,109 @@
+package br.com.eightbitbazar.application.usecase.user;
+
+import br.com.eightbitbazar.application.port.out.ListingRepository;
+import br.com.eightbitbazar.application.port.out.PurchaseRepository;
+import br.com.eightbitbazar.domain.listing.ItemCondition;
+import br.com.eightbitbazar.domain.listing.Listing;
+import br.com.eightbitbazar.domain.listing.ListingId;
+import br.com.eightbitbazar.domain.listing.ListingStatus;
+import br.com.eightbitbazar.domain.listing.ListingType;
+import br.com.eightbitbazar.domain.purchase.PaymentMethod;
+import br.com.eightbitbazar.domain.purchase.Purchase;
+import br.com.eightbitbazar.domain.purchase.PurchaseStatus;
+import br.com.eightbitbazar.domain.purchase.PurchaseType;
+import br.com.eightbitbazar.domain.user.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetMySalesTest {
+
+    @Mock
+    private PurchaseRepository purchaseRepository;
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    private GetMySales getMySales;
+
+    @BeforeEach
+    void setUp() {
+        getMySales = new GetMySales(purchaseRepository, listingRepository);
+    }
+
+    @Test
+    void shouldReturnSellerHistoryWithListingSummary() {
+        UserId sellerId = new UserId(20L);
+        ListingId listingId = new ListingId(77L);
+        Purchase purchase = new Purchase(
+            150L,
+            listingId,
+            new UserId(10L),
+            sellerId,
+            new BigDecimal("150.00"),
+            PurchaseType.AUCTION_WIN,
+            PaymentMethod.OTHER,
+            BigDecimal.ZERO,
+            new BigDecimal("150.00"),
+            PurchaseStatus.PENDING,
+            LocalDateTime.of(2026, 3, 1, 11, 30)
+        );
+        Listing listing = new Listing(
+            listingId,
+            sellerId,
+            "Resident Evil 2",
+            "Midia original",
+            1L,
+            2L,
+            ItemCondition.COMPLETE,
+            0,
+            ListingType.AUCTION,
+            null,
+            new BigDecimal("80.00"),
+            new BigDecimal("150.00"),
+            LocalDateTime.of(2026, 3, 1, 9, 0),
+            null,
+            ListingStatus.SOLD,
+            List.of(),
+            LocalDateTime.of(2026, 2, 27, 12, 0),
+            LocalDateTime.of(2026, 3, 1, 11, 30),
+            null
+        );
+
+        when(purchaseRepository.findBySellerId(sellerId, PageRequest.of(0, 20)))
+            .thenReturn(new PageImpl<>(List.of(purchase), PageRequest.of(0, 20), 1));
+        when(listingRepository.findByIds(Set.of(listingId))).thenReturn(List.of(listing));
+
+        Page<UserTradeHistoryItemOutput> output = getMySales.execute(sellerId, 0, 20);
+
+        assertEquals(1, output.getTotalElements());
+        assertEquals(150L, output.getContent().get(0).purchaseId());
+        assertEquals(77L, output.getContent().get(0).listingId());
+        assertEquals("Resident Evil 2", output.getContent().get(0).listingTitle());
+        assertEquals("AUCTION", output.getContent().get(0).listingType());
+        assertEquals("SOLD", output.getContent().get(0).listingStatus());
+        assertEquals(new BigDecimal("150.00"), output.getContent().get(0).amount());
+        assertEquals(new BigDecimal("150.00"), output.getContent().get(0).finalAmount());
+        assertEquals("OTHER", output.getContent().get(0).paymentMethod());
+        assertEquals("PENDING", output.getContent().get(0).purchaseStatus());
+        assertEquals(LocalDateTime.of(2026, 3, 1, 11, 30), output.getContent().get(0).createdAt());
+
+        verify(purchaseRepository).findBySellerId(sellerId, PageRequest.of(0, 20));
+        verify(listingRepository).findByIds(Set.of(listingId));
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -85,8 +86,9 @@ class GetMySalesTest {
             null
         );
 
-        when(purchaseRepository.findBySellerId(sellerId, PageRequest.of(0, 20)))
-            .thenReturn(new PageImpl<>(List.of(purchase), PageRequest.of(0, 20), 1));
+        PageRequest pageRequest = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        when(purchaseRepository.findBySellerId(sellerId, pageRequest))
+            .thenReturn(new PageImpl<>(List.of(purchase), pageRequest, 1));
         when(listingRepository.findByIds(Set.of(listingId))).thenReturn(List.of(listing));
 
         Page<UserTradeHistoryItemOutput> output = getMySales.execute(sellerId, 0, 20);
@@ -103,7 +105,7 @@ class GetMySalesTest {
         assertEquals("PENDING", output.getContent().get(0).purchaseStatus());
         assertEquals(LocalDateTime.of(2026, 3, 1, 11, 30), output.getContent().get(0).createdAt());
 
-        verify(purchaseRepository).findBySellerId(sellerId, PageRequest.of(0, 20));
+        verify(purchaseRepository).findBySellerId(sellerId, pageRequest);
         verify(listingRepository).findByIds(Set.of(listingId));
     }
 }

--- a/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
+++ b/src/test/java/br/com/eightbitbazar/application/usecase/user/GetMySalesTest.java
@@ -44,7 +44,8 @@ class GetMySalesTest {
 
     @BeforeEach
     void setUp() {
-        getMySales = new GetMySales(purchaseRepository, listingRepository);
+        UserTradeHistoryMapper tradeHistoryMapper = new UserTradeHistoryMapper(listingRepository);
+        getMySales = new GetMySales(purchaseRepository, tradeHistoryMapper);
     }
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,3 +29,9 @@ minio:
   access-key: minioadmin
   secret-key: minioadmin
   bucket: eightbitbazar-test
+
+app:
+  auctions:
+    closing:
+      enabled: false
+      fixed-delay: 60000


### PR DESCRIPTION
Closes #20

## Resumo

Adiciona o histórico comercial do usuário e o fluxo de fechamento automático de leilões. Aplica hardening de concorrência, controle por feature flag e endurecimento de paginação.

## Endpoints adicionados

| Método | Rota | Descrição |
|--------|------|-----------|
| GET | `/api/v1/users/me/purchases` | Histórico de compras do usuário autenticado (paginado, DESC por data) |
| GET | `/api/v1/users/me/sales` | Histórico de vendas do usuário autenticado (paginado, DESC por data) |

## O que mudou

**Histórico comercial**
- Endpoints `/users/me/purchases` e `/users/me/sales` com paginação ordenada por `createdAt DESC`
- Validação de `page` (≥ 0) e `size` (1–100) no controller — retorna `400` para valores inválidos
- `UserTradeHistoryMapper` extrai a lógica de mapeamento duplicada de `GetMyPurchases` e `GetMySales`

**Fechamento de leilões**
- Fluxo idempotente: busca apenas IDs candidatos e recarrega cada leilão com `PESSIMISTIC_WRITE` antes de fechar
- Scheduler controlado por `app.auctions.closing.enabled` — desligado por padrão em produção e em testes
- Listener RabbitMQ consome `purchase.events` para registrar vendas de leilão

## Commits

- `feat`: add user trade history and auction closing flows
- `fix`: make auction closing idempotent
- `fix`: guard auction closing scheduler by property
- `fix`: harden trade history pagination
- `test`: add shouldListSalesNewestFirst integration test
- `refactor`: share trade history mapping

## Exemplos de uso

```bash
# Histórico de compras (primeira página)
curl -H 'Authorization: Bearer $TOKEN' \
  'http://localhost:8080/api/v1/users/me/purchases?page=0&size=20'

# Histórico de vendas
curl -H 'Authorization: Bearer $TOKEN' \
  'http://localhost:8080/api/v1/users/me/sales?page=0&size=20'
```

## Testes executados

```bash
./gradlew test   # BUILD SUCCESSFUL
```

Cobertura inclui: testes unitários dos use cases, integração dos endpoints de histórico (paginação inválida, ordenação), fechamento de leilão (idempotência, scheduler desabilitado) e listener de eventos de compra.