### PR TITLE
feat: separar user MDC em filtro pós-autenticação

### DIFF
--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/BidController.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/BidController.java
@@ -38,7 +38,6 @@ public class BidController {
         PlaceBidInput input = new PlaceBidInput(listingId, request.amount());
         log.atInfo()
             .addKeyValue("listingId", listingId)
-            .addKeyValue("userId", userId.value())
             .addKeyValue("amount", request.amount())
             .log("bid.place.requested");
         PlaceBidOutput output = placeBidUseCase.execute(userId, input);

--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/UserController.java
@@ -117,9 +117,7 @@ public class UserController {
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteProfile(@AuthenticationPrincipal Jwt jwt) {
         UserId userId = new UserId(Long.parseLong(jwt.getSubject()));
-        log.atWarn()
-            .addKeyValue("userId", userId.value())
-            .log("user.delete.requested");
+        log.atWarn().log("user.delete.requested");
         deleteUserUseCase.execute(userId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/br/com/eightbitbazar/adapter/in/web/filter/UserMdcFilter.java
+++ b/src/main/java/br/com/eightbitbazar/adapter/in/web/filter/UserMdcFilter.java
@@ -5,17 +5,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
-import org.springframework.stereotype.Component;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 
-@Component
-public class CorrelationIdFilter extends OncePerRequestFilter {
-
-    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+public class UserMdcFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -23,22 +21,14 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
                                     FilterChain chain) throws ServletException, IOException {
         Map<String, String> previousMdc = MDC.getCopyOfContextMap();
         try {
-            String raw = request.getHeader(CORRELATION_ID_HEADER);
-            String correlationId;
-            if (raw == null || raw.isBlank()) {
-                correlationId = UUID.randomUUID().toString();
-            } else {
-                // Strip control characters and enforce length
-                String sanitized = raw.replaceAll("[\\r\\n]", "").strip();
-                if (sanitized.isBlank() || sanitized.length() > 64) {
-                    correlationId = UUID.randomUUID().toString();
-                } else {
-                    correlationId = sanitized;
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+                String userId = jwt.getSubject();
+                if (userId != null) {
+                    MDC.put("userId", userId);
                 }
             }
-            MDC.put("correlationId", correlationId);
 
-            response.setHeader(CORRELATION_ID_HEADER, correlationId);
             chain.doFilter(request, response);
         } finally {
             if (previousMdc == null) {

--- a/src/main/java/br/com/eightbitbazar/application/usecase/bid/PlaceBid.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/bid/PlaceBid.java
@@ -86,7 +86,6 @@ public class PlaceBid implements PlaceBidUseCase {
 
         log.atInfo()
             .addKeyValue("listingId", input.listingId())
-            .addKeyValue("userId", userId.value())
             .addKeyValue("amount", input.amount())
             .log("bid.placing");
 
@@ -103,7 +102,6 @@ public class PlaceBid implements PlaceBidUseCase {
         log.atInfo()
             .addKeyValue("bidId", savedBid.id())
             .addKeyValue("listingId", savedBid.listingId().value())
-            .addKeyValue("userId", userId.value())
             .log("bid.saved");
 
         eventPublisher.publish(new BidPlacedEvent(

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/DeleteUser.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/DeleteUser.java
@@ -25,14 +25,12 @@ public class DeleteUser implements DeleteUserUseCase {
             .orElseThrow(() -> new NotFoundException("User not found"));
 
         log.atWarn()
-            .addKeyValue("userId", userId.value())
             .log("user.deleting");
 
         User deletedUser = user.withDeletedAt(LocalDateTime.now());
         userRepository.save(deletedUser);
 
         log.atWarn()
-            .addKeyValue("userId", userId.value())
             .log("user.deleted");
     }
 }

--- a/src/main/java/br/com/eightbitbazar/application/usecase/user/UpdateUserProfile.java
+++ b/src/main/java/br/com/eightbitbazar/application/usecase/user/UpdateUserProfile.java
@@ -50,7 +50,6 @@ public class UpdateUserProfile implements UpdateUserProfileUseCase {
         User savedUser = userRepository.save(updatedUser);
 
         log.atInfo()
-            .addKeyValue("userId", savedUser.id().value())
             .log("user.profile.updated");
 
         return new UpdateUserProfileOutput(

--- a/src/main/java/br/com/eightbitbazar/config/SecurityConfig.java
+++ b/src/main/java/br/com/eightbitbazar/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package br.com.eightbitbazar.config;
 
+import br.com.eightbitbazar.adapter.in.web.filter.UserMdcFilter;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
@@ -80,6 +82,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated()
             )
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())))
+            .addFilterAfter(new UserMdcFilter(), BearerTokenAuthenticationFilter.class)
             .formLogin(Customizer.withDefaults());
 
         return http.build();

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <springProfile name="dev,local,local-podman">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] [userId=%X{userId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">
@@ -15,7 +15,7 @@
     <springProfile name="test">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] [userId=%X{userId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <springProfile name="dev,local,local-podman">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}]%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}%replace(%X{correlationId}){'^(.+)$',' [correlationId=$1]'}%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">
@@ -15,7 +15,7 @@
     <springProfile name="test">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}]%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}%replace(%X{correlationId}){'^(.+)$',' [correlationId=$1]'}%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <springProfile name="dev,local,local-podman">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] [userId=%X{userId}] - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">
@@ -15,7 +15,7 @@
     <springProfile name="test">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] [userId=%X{userId}] - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <springProfile name="dev,local,local-podman">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}]%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">
@@ -15,7 +15,7 @@
     <springProfile name="test">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}] - %msg %kvp%n</pattern>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{correlationId}]%replace(%X{userId}){'^(.+)$',' [userId=$1]'} - %msg %kvp%n</pattern>
             </encoder>
         </appender>
         <root level="INFO">

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/filter/CorrelationIdFilterTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/filter/CorrelationIdFilterTest.java
@@ -7,11 +7,6 @@ import org.slf4j.MDC;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,7 +28,6 @@ class CorrelationIdFilterTest {
     @AfterEach
     void tearDown() {
         MDC.clear();
-        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -61,7 +55,6 @@ class CorrelationIdFilterTest {
         filter.doFilterInternal(request, response, chain);
 
         assertThat(MDC.get("correlationId")).isNull();
-        assertThat(MDC.get("userId")).isNull();
     }
 
     @Test
@@ -94,31 +87,6 @@ class CorrelationIdFilterTest {
     }
 
     @Test
-    void shouldSetUserIdInMdcWhenAuthenticated() throws Exception {
-        var jwt = Jwt.withTokenValue("token")
-            .header("alg", "RS256")
-            .subject("user-42")
-            .issuedAt(java.time.Instant.now())
-            .expiresAt(java.time.Instant.now().plusSeconds(60))
-            .build();
-        var auth = new JwtAuthenticationToken(jwt, List.of());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        var capturedUserId = new String[1];
-        var capturingChain = new MockFilterChain() {
-            @Override
-            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
-                    throws java.io.IOException, jakarta.servlet.ServletException {
-                capturedUserId[0] = MDC.get("userId");
-            }
-        };
-
-        filter.doFilterInternal(request, response, capturingChain);
-
-        assertThat(capturedUserId[0]).isEqualTo("user-42");
-    }
-
-    @Test
     void shouldSanitizeCRLFFromCorrelationIdHeader() throws Exception {
         request.addHeader("X-Correlation-Id", "valid-id\r\nX-Injected: header");
 
@@ -137,5 +105,15 @@ class CorrelationIdFilterTest {
 
         assertThat(response.getHeader("X-Correlation-Id"))
             .matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    void shouldRestorePreviousMdcAfterRequest() throws Exception {
+        MDC.put("existing", "value");
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(MDC.get("existing")).isEqualTo("value");
+        assertThat(MDC.get("correlationId")).isNull();
     }
 }

--- a/src/test/java/br/com/eightbitbazar/adapter/in/web/filter/UserMdcFilterTest.java
+++ b/src/test/java/br/com/eightbitbazar/adapter/in/web/filter/UserMdcFilterTest.java
@@ -1,0 +1,176 @@
+package br.com.eightbitbazar.adapter.in.web.filter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserMdcFilterTest {
+
+    private UserMdcFilter filter;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        filter = new UserMdcFilter();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldSetUserIdInMdcWhenPrincipalIsJwt() throws Exception {
+        var jwt = Jwt.withTokenValue("token")
+            .header("alg", "RS256")
+            .subject("user-42")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(60))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+
+        var capturedUserId = new String[1];
+        var chain = new MockFilterChain() {
+            @Override
+            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
+                    throws java.io.IOException, jakarta.servlet.ServletException {
+                capturedUserId[0] = MDC.get("userId");
+                super.doFilter(req, res);
+            }
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(capturedUserId[0]).isEqualTo("user-42");
+    }
+
+    @Test
+    void shouldNotSetUserIdWhenAuthenticationIsAbsent() throws Exception {
+        var capturedUserId = new String[1];
+        var chain = new MockFilterChain() {
+            @Override
+            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
+                    throws java.io.IOException, jakarta.servlet.ServletException {
+                capturedUserId[0] = MDC.get("userId");
+                super.doFilter(req, res);
+            }
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(capturedUserId[0]).isNull();
+    }
+
+    @Test
+    void shouldNotSetUserIdWhenPrincipalIsNotJwt() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken("principal", "credentials")
+        );
+
+        var capturedUserId = new String[1];
+        var chain = new MockFilterChain() {
+            @Override
+            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
+                    throws java.io.IOException, jakarta.servlet.ServletException {
+                capturedUserId[0] = MDC.get("userId");
+                super.doFilter(req, res);
+            }
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(capturedUserId[0]).isNull();
+    }
+
+    @Test
+    void shouldPreserveExistingCorrelationIdDuringRequest() throws Exception {
+        MDC.put("correlationId", "trace-123");
+        var jwt = Jwt.withTokenValue("token")
+            .header("alg", "RS256")
+            .subject("user-42")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(60))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+
+        var capturedCorrelationId = new String[1];
+        var capturedUserId = new String[1];
+        var chain = new MockFilterChain() {
+            @Override
+            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
+                    throws java.io.IOException, jakarta.servlet.ServletException {
+                capturedCorrelationId[0] = MDC.get("correlationId");
+                capturedUserId[0] = MDC.get("userId");
+                super.doFilter(req, res);
+            }
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(capturedCorrelationId[0]).isEqualTo("trace-123");
+        assertThat(capturedUserId[0]).isEqualTo("user-42");
+    }
+
+    @Test
+    void shouldRestorePreviousMdcAfterRequest() throws Exception {
+        MDC.put("correlationId", "trace-123");
+        MDC.put("existing", "value");
+        var jwt = Jwt.withTokenValue("token")
+            .header("alg", "RS256")
+            .subject("user-42")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(60))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+
+        filter.doFilterInternal(request, response, new MockFilterChain());
+
+        assertThat(MDC.get("correlationId")).isEqualTo("trace-123");
+        assertThat(MDC.get("existing")).isEqualTo("value");
+        assertThat(MDC.get("userId")).isNull();
+    }
+
+    @Test
+    void shouldRestorePreviousMdcWhenChainThrows() {
+        MDC.put("correlationId", "trace-123");
+        var jwt = Jwt.withTokenValue("token")
+            .header("alg", "RS256")
+            .subject("user-42")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(60))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt, List.of()));
+        var failingChain = new MockFilterChain() {
+            @Override
+            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res)
+                    throws java.io.IOException {
+                throw new java.io.IOException("boom");
+            }
+        };
+
+        assertThatThrownBy(() -> filter.doFilterInternal(request, response, failingChain))
+            .isInstanceOf(java.io.IOException.class)
+            .hasMessage("boom");
+
+        assertThat(MDC.get("correlationId")).isEqualTo("trace-123");
+        assertThat(MDC.get("userId")).isNull();
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
+++ b/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
@@ -48,14 +48,6 @@ class NoDuplicateUserIdLogFieldsTest {
         }
     }
 
-    @Test
-    void textLogPatternsRenderUserIdFromMdc() throws IOException {
-        Path logbackConfig = PROJECT_ROOT.resolve("src/main/resources/logback-spring.xml");
-
-        assertThat(Files.readString(logbackConfig))
-            .contains("[userId=%X{userId}]");
-    }
-
     private static boolean containsManualUserIdLogField(Path path) {
         try {
             return Files.readString(path).contains(".addKeyValue(\"userId\"");

--- a/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
+++ b/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
@@ -1,0 +1,66 @@
+package br.com.eightbitbazar.observability;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoDuplicateUserIdLogFieldsTest {
+
+    private static final Path PROJECT_ROOT = Path.of("").toAbsolutePath();
+
+    @Test
+    void onlyUnauthenticatedIdentityCreationLogsAddUserIdManually() throws IOException {
+        Path mainSourceRoot = PROJECT_ROOT.resolve("src/main/java/br/com/eightbitbazar");
+        Set<Path> allowedFiles = Set.of(
+            PROJECT_ROOT.resolve("src/main/java/br/com/eightbitbazar/application/usecase/user/RegisterUser.java"),
+            PROJECT_ROOT.resolve("src/main/java/br/com/eightbitbazar/adapter/in/web/AuthController.java")
+        );
+
+        try (Stream<Path> javaFiles = Files.walk(mainSourceRoot)) {
+            List<Path> filesWithManualUserId = javaFiles
+                .filter(path -> path.toString().endsWith(".java"))
+                .filter(path -> containsManualUserIdLogField(path))
+                .toList();
+
+            assertThat(filesWithManualUserId)
+                .containsExactlyInAnyOrderElementsOf(allowedFiles);
+        }
+    }
+
+    @Test
+    void unauthenticatedIdentityCreationLogsKeepExplicitUserId() throws IOException {
+        List<Path> unauthenticatedIdentityFiles = List.of(
+            PROJECT_ROOT.resolve("src/main/java/br/com/eightbitbazar/application/usecase/user/RegisterUser.java"),
+            PROJECT_ROOT.resolve("src/main/java/br/com/eightbitbazar/adapter/in/web/AuthController.java")
+        );
+
+        for (Path sourceFile : unauthenticatedIdentityFiles) {
+            assertThat(Files.readString(sourceFile))
+                .as(sourceFile.toString())
+                .contains(".addKeyValue(\"userId\"");
+        }
+    }
+
+    @Test
+    void textLogPatternsRenderUserIdFromMdc() throws IOException {
+        Path logbackConfig = PROJECT_ROOT.resolve("src/main/resources/logback-spring.xml");
+
+        assertThat(Files.readString(logbackConfig))
+            .contains("[userId=%X{userId}]");
+    }
+
+    private static boolean containsManualUserIdLogField(Path path) {
+        try {
+            return Files.readString(path).contains(".addKeyValue(\"userId\"");
+        } catch (IOException exception) {
+            throw new IllegalStateException("Could not read " + path, exception);
+        }
+    }
+}

--- a/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
+++ b/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
@@ -49,11 +49,13 @@ class NoDuplicateUserIdLogFieldsTest {
     }
 
     @Test
-    void textLogPatternsRenderUserIdOnlyWhenMdcHasValue() throws IOException {
+    void textLogPatternsRenderMdcIdentifiersOnlyWhenTheyHaveValues() throws IOException {
         Path logbackConfig = PROJECT_ROOT.resolve("src/main/resources/logback-spring.xml");
 
         assertThat(Files.readString(logbackConfig))
+            .contains("%replace(%X{correlationId}){'^(.+)$',' [correlationId=$1]'}")
             .contains("%replace(%X{userId}){'^(.+)$',' [userId=$1]'}")
+            .doesNotContain("[%X{correlationId}]")
             .doesNotContain("[userId=%X{userId}]");
     }
 

--- a/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
+++ b/src/test/java/br/com/eightbitbazar/observability/NoDuplicateUserIdLogFieldsTest.java
@@ -48,6 +48,15 @@ class NoDuplicateUserIdLogFieldsTest {
         }
     }
 
+    @Test
+    void textLogPatternsRenderUserIdOnlyWhenMdcHasValue() throws IOException {
+        Path logbackConfig = PROJECT_ROOT.resolve("src/main/resources/logback-spring.xml");
+
+        assertThat(Files.readString(logbackConfig))
+            .contains("%replace(%X{userId}){'^(.+)$',' [userId=$1]'}")
+            .doesNotContain("[userId=%X{userId}]");
+    }
+
     private static boolean containsManualUserIdLogField(Path path) {
         try {
             return Files.readString(path).contains(".addKeyValue(\"userId\"");


### PR DESCRIPTION
## Resumo

- separa o `CorrelationIdFilter` para ele cuidar apenas do `correlationId` da request
- adiciona `UserMdcFilter` para copiar o subject do JWT autenticado para o MDC como `userId`
- registra o `UserMdcFilter` depois da autenticação Bearer/JWT na `SecurityFilterChain` padrão da API
- adiciona testes focados para o comportamento de correlation id e user MDC

Closes #23

## Motivação

O filtro anterior misturava duas responsabilidades com requisitos de ordem diferentes: `correlationId` precisa existir cedo na request, enquanto `userId` só é confiável depois que o Spring Security autentica o token Bearer.

## Validação

- `./gradlew test --tests br.com.eightbitbazar.adapter.in.web.filter.CorrelationIdFilterTest`
- `./gradlew test --tests br.com.eightbitbazar.adapter.in.web.filter.UserMdcFilterTest`
- `./gradlew test`